### PR TITLE
Add English documentation for all main packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,185 @@
+# Boost
+
 [![Go](https://github.com/xgodev/boost/actions/workflows/go.yml/badge.svg)](https://github.com/xgodev/boost/actions/workflows/go.yml)
 
-# boost
+## Overview
+
+Boost is a modular and extensible framework for Go application development, designed to simplify the creation of robust, scalable, and observable services. The framework provides a comprehensive set of components that can be used independently or combined to build complete applications.
+
+## Key Features
+
+- **Modular Architecture**: Independent components that can be used as needed
+- **Dependency Injection**: Flexible system for managing dependencies between components
+- **Integrated Observability**: Native support for metrics, logging, and tracing
+- **Adapters for Popular Libraries**: Consistent wrappers for various libraries in the Go ecosystem
+- **Design Patterns**: Implementations of patterns such as Factory, Middleware, and Wrapper
+- **CloudEvents Support**: Native integration with the CloudEvents standard
+- **Extensibility**: Easy to add support for new libraries and frameworks
+
+## Project Structure
+
+The project is organized into modular packages, each with specific responsibilities:
+
+- **bootstrap**: Components for application initialization
+- **examples**: Framework usage examples
+- **extra**: Additional functionalities (health checks, middleware, multiserver)
+- **factory**: Factory pattern implementations for various components
+- **fx**: Dependency injection and lifecycle management
+- **model**: Data structures and interfaces definitions
+- **utils**: Various utilities
+- **wrapper**: Adapters for external libraries (cache, config, log, publisher)
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.18 or higher
+- Specific dependencies vary according to the components used
+
+### Installation
+
+```bash
+go get github.com/xgodev/boost
+```
+
+### Basic Example
+
+```go
+package main
+
+import (
+	"github.com/xgodev/boost"
+	"github.com/xgodev/boost/factory/contrib/go.uber.org/zap/v1"
+	"github.com/xgodev/boost/wrapper/log"
+	"os"
+)
+
+func init() {
+	os.Setenv("BOOST_FACTORY_ZAP_CONSOLE_FORMATTER", "JSON")
+	os.Setenv("BOOST_FACTORY_ZAP_CONSOLE_LEVEL", "DEBUG")
+}
+
+func main() {
+	boost.Start()
+	log.Set(zap.NewLogger())
+	log.Infof("hello world!!")
+}
+```
+
+## Main Components
+
+### Bootstrap
+
+The Bootstrap package provides components for application initialization, including support for serverless functions and event processing.
+
+[Bootstrap Documentation](./bootstrap/README.md)
+
+### Factory
+
+The Factory package implements the Factory design pattern for various components, facilitating the creation and configuration of complex objects.
+
+[Factory Documentation](./factory/README.md)
+
+### Wrapper
+
+The Wrapper package provides adapters for external libraries, including cache, configuration, logging, and message publishing.
+
+[Wrapper Documentation](./wrapper/README.md)
+
+### FX
+
+The FX package provides dependency injection and component lifecycle management functionalities.
+
+[FX Documentation](./fx/README.md)
+
+### Extra
+
+The Extra package includes additional functionalities such as health checks, middleware, and support for multiple servers.
+
+[Extra Documentation](./extra/README.md)
+
+## Integration with Popular Technologies
+
+Boost offers extensive integrations with a wide range of technologies:
+
+### Cloud Providers
+- **AWS**: AWS SDK integration for various services
+- **Google Cloud Platform**: 
+  - Pub/Sub
+  - BigQuery
+  - Firestore
+  - API integration
+  - gRPC
+
+### Databases
+- **MongoDB**: Native driver integration
+- **PostgreSQL**: pgx driver
+- **Oracle**: godror driver
+- **CockroachDB**: Compatible with PostgreSQL drivers
+- **Cassandra**: gocql driver
+- **BuntDB**: In-memory key/value database
+- **MemDB**: In-memory database with immutable radix tree
+
+### Caching
+- **Redis**: go-redis client
+- **BigCache**: In-memory caching system
+- **FreeCache**: Zero GC cache library
+
+### Messaging & Event Systems
+- **NATS**: Lightweight messaging system
+- **Kafka**: Confluent Kafka Go client
+- **CloudEvents**: SDK for CloudEvents standard
+- **Go Cloud Pub/Sub**: Cloud-agnostic pub/sub API
+
+### Web & API
+- **Echo**: High performance web framework
+- **gRPC**: High performance RPC framework
+- **GraphQL**: GraphQL server implementation
+- **Swagger**: API documentation with echo-swagger
+
+### Observability
+- **Prometheus**: Metrics and monitoring
+- **OpenTelemetry**: Observability framework
+- **Datadog**: APM and monitoring
+- **Zap**: Structured logging
+- **Zerolog**: Zero-allocation JSON logger
+- **Logrus**: Structured logger
+
+### Configuration
+- **Koanf**: Lightweight, extensible configuration management
+- **Cobra**: CLI application library
+- **Viper**: Configuration solution (via Koanf)
+
+### Resilience & Patterns
+- **Hystrix**: Latency and fault tolerance library
+- **Ants**: Goroutine pool
+- **FTP**: FTP client
+- **Kubernetes**: Client-go integration
+- **Vault**: HashiCorp Vault client
+
+### Serialization
+- **JSON**: Multiple implementations (standard, go-json)
+- **MessagePack**: Binary serialization
+- **GOB**: Go's native binary format
+
+## Contributing
+
+Contributions are welcome! To contribute:
+
+1. Fork the repository
+2. Create a branch for your feature (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the terms included in the [LICENSE](./LICENSE) file.
+
+## Contact
+
+For questions, suggestions, or contributions, please open an issue in the GitHub repository.
+
+---
+
+Developed with ❤️ by the xgodev community.

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,46 @@
+# Bootstrap
+
+The Bootstrap package is responsible for providing components and utilities for initializing applications in the Boost framework. This package serves as a foundation for configuring and starting applications in a standardized and efficient manner.
+
+## Overview
+
+Bootstrap acts as an entry point for applications built with the Boost framework, offering structures and patterns for service initialization. It defines fundamental constants and provides mechanisms for initial application configuration.
+
+## Main Components
+
+### Function
+
+The `function` subpackage provides structures and utilities for working with functions as processing units, especially in the context of cloud events (Cloud Events). It includes:
+
+- Handlers for event processing
+- Middleware for intercepting and modifying execution flows
+- Adapters for different protocols and formats
+- Wrappers for functions that facilitate integration with the Boost ecosystem
+
+### Examples
+
+The `examples` directory contains reference implementations that demonstrate how to use the Bootstrap package in different scenarios, including:
+
+- Integration with CloudEvents
+- Usage with NATS
+- Application initialization patterns
+
+## How to Use
+
+To use the Bootstrap package in your application:
+
+1. Import the package in your code
+2. Configure the necessary parameters
+3. Use the Function components to process events or start services
+
+## Integration with Other Packages
+
+Bootstrap integrates with other components of the Boost framework, such as:
+
+- Wrapper: for configuration and logging
+- Factory: for component creation
+- Extra: for additional functionalities like middleware and health checks
+
+## Contribution
+
+Contributions to the Bootstrap package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Examples
+
+The Examples package provides reference implementations and practical demonstrations of how to use the various components of the Boost framework. This package serves as executable documentation and a starting point for developers who want to learn how to use the framework.
+
+## Overview
+
+Examples contains complete applications and code snippets that illustrate usage patterns, best practices, and common use cases for the Boost framework. These examples are designed to be clear, concise, and educational, easing the learning curve for new users.
+
+## Main Components
+
+### Boot
+
+The `boot` subpackage demonstrates how to initialize applications using the Boost framework. It includes examples of:
+
+- Basic application configuration
+- Component initialization
+- Integration of different modules
+- Application lifecycle management
+
+These examples serve as a starting point for developers who want to create new applications with the Boost framework, illustrating the recommended patterns for project structuring and initialization.
+
+## How to Use
+
+The examples are designed to be executed directly, allowing developers to experience the framework's behavior firsthand. To use the examples:
+
+1. Navigate to the directory of the specific example you want to explore
+2. Read the source code and comments to understand the purpose and structure of the example
+3. Execute the example following the provided instructions
+4. Try modifying the example to explore different configurations and behaviors
+
+## Integration with Other Packages
+
+The examples demonstrate the integration between various components of the Boost framework:
+
+- Bootstrap: For application initialization
+- Factory: For creating component instances
+- Wrapper: For using adapters to external libraries
+- Extra: For additional functionalities like middleware and health checks
+
+## Contribution
+
+Contributions to the Examples package are especially welcome, as quality examples are essential for the adoption and effective use of the framework. When contributing:
+
+1. Make sure the example is clear and focuses on a specific aspect of the framework
+2. Include detailed comments explaining the purpose and functioning of the code
+3. Provide clear instructions on how to run and experiment with the example
+4. Consider adding variations that demonstrate different configurations or use cases
+
+Well-documented and educational examples are a valuable way to contribute to the Boost ecosystem, helping new users understand and effectively use the framework.

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,0 +1,70 @@
+# Extra
+
+The Extra package provides additional and complementary functionalities that enrich the Boost framework but don't fit directly into the main packages. This package contains components that add value to the framework, offering solutions for specific use cases.
+
+## Overview
+
+Extra includes implementations for common needs in modern applications, such as health checks, middleware for request interception, and support for multiple servers. These components are designed to be modular and easily integrable with the rest of the framework.
+
+## Main Components
+
+### Health
+
+The `health` subpackage provides implementations for application and service health checks. It includes:
+
+- Endpoints for status verification
+- Checkers for different system components
+- Aggregators to consolidate results from multiple checks
+
+This component is essential for monitoring and operating applications in production environments, allowing quick detection of problems and facilitating the implementation of recovery strategies.
+
+### Middleware
+
+The `middleware` subpackage offers middleware implementations for intercepting and modifying execution flows. It includes middleware for:
+
+- Request and response logging
+- Authentication and authorization
+- Error handling
+- Metrics and monitoring
+- Rate limiting
+
+These middleware can be composed and applied at different points in the application, allowing the implementation of cross-cutting functionalities in a modular and reusable way.
+
+### Multiserver
+
+The `multiserver` subpackage provides support for running multiple servers in a single application. It allows:
+
+- Coordinated initialization and management of servers
+- Resource sharing between servers
+- Graceful shutdown of all servers
+
+This component is useful for applications that need to expose multiple interfaces, such as REST APIs, gRPC, and administration interfaces, in a single instance.
+
+## How to Use
+
+To use the Extra package in your application:
+
+1. Import the specific subpackage containing the desired functionalities
+2. Configure the components as needed
+3. Integrate the components with the rest of your application
+
+## Integration with Other Packages
+
+Extra integrates with other components of the Boost framework:
+
+- Bootstrap: For component initialization and configuration
+- Factory: For creating instances of specific implementations
+- Wrapper: For accessing adapters to external libraries
+- Model: For defining interfaces and structures
+
+## Extensibility
+
+The Extra package was designed to be easily extensible. To add new functionalities:
+
+1. Identify the appropriate subpackage or create a new one if necessary
+2. Implement the components following existing patterns
+3. Add appropriate tests and documentation
+
+## Contribution
+
+Contributions to the Extra package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/factory/README.md
+++ b/factory/README.md
@@ -1,0 +1,59 @@
+# Factory
+
+The Factory package implements the Factory design pattern for various components of the Boost framework, facilitating the creation and configuration of complex objects. This package is fundamental to the modular and extensible architecture of the framework.
+
+## Overview
+
+Factory provides a standardized approach to instantiate objects, allowing client code to request objects without knowing the specific details of how they are created. This promotes decoupling between components and facilitates system extensibility.
+
+## Main Components
+
+### Core
+
+The `core` subpackage contains factory implementations for fundamental system components, organized into categories:
+
+- **Database**: Factories for database connections and operations
+- **Net**: Components related to networks and communication
+- **Time**: Utilities related to time and scheduling
+
+### Contrib
+
+The `contrib` directory contains factory implementations for integration with third-party libraries and frameworks, including:
+
+- gRPC: For communication between services
+- Google Cloud Platform (GCP): Integration with GCP services
+- Confluent: For working with Apache Kafka
+- Ollama: Integration with AI models
+- Spf13/Cobra: For creating command-line interfaces
+
+### Local
+
+The `local` subpackage provides specific implementations for local use or development environments, facilitating testing and rapid prototyping.
+
+## How to Use
+
+To use the Factory package in your application:
+
+1. Import the specific subpackage that contains the desired factory
+2. Configure the necessary parameters
+3. Use the factory to create instances of the required objects
+
+## Integration with Other Packages
+
+The Factory integrates with other components of the Boost framework:
+
+- Bootstrap: For application initialization
+- Wrapper: For configuration and logging
+- Model: For data structure definitions
+
+## Extensibility
+
+The Factory package was designed to be easily extensible. To add support for new libraries or frameworks:
+
+1. Create a new subpackage in `contrib` with the name of the library
+2. Implement the necessary factory interfaces
+3. Add appropriate tests and documentation
+
+## Contribution
+
+Contributions to the Factory package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/fx/README.md
+++ b/fx/README.md
@@ -1,0 +1,47 @@
+# FX
+
+The FX package provides dependency injection and component lifecycle management functionalities for applications built with the Boost framework. This package is essential for building modular and testable applications.
+
+## Overview
+
+FX simplifies the creation and management of dependencies between components, allowing developers to define reusable modules and compose complex applications in an organized manner. It draws inspiration from dependency injection frameworks, adapted for the Go ecosystem.
+
+## Main Components
+
+### Modules
+
+The `modules` subpackage contains implementations of pre-defined modules that can be used to compose applications. These modules encapsulate common functionalities and can be easily integrated into different applications.
+
+The available modules include integrations with various components of the Boost ecosystem, such as caching systems, configuration, logging, and message publishing. Each module is designed to be independent and easily combinable with other modules.
+
+## How to Use
+
+To use the FX package in your application:
+
+1. Import the package and the specific modules you want to use
+2. Define your own modules to encapsulate business logic
+3. Compose the modules to create your application
+4. Use the dependency injection system to access components in your code
+
+FX automatically manages the lifecycle of components, ensuring they are initialized in the correct order and properly finalized when the application is terminated.
+
+## Integration with Other Packages
+
+FX deeply integrates with other components of the Boost framework:
+
+- Bootstrap: For application initialization
+- Factory: For creating component instances
+- Wrapper: For accessing adapters to external libraries
+- Model: For defining interfaces and structures
+
+## Extensibility
+
+The FX package was designed to be easily extensible. To add new modules:
+
+1. Create a new subpackage in `modules` with the name of the module
+2. Implement the necessary interfaces to define the module
+3. Add appropriate tests and documentation
+
+## Contribution
+
+Contributions to the FX package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,58 @@
+# Model
+
+The Model package defines the fundamental data structures and interfaces used throughout the Boost framework. This package serves as the foundation for data representation and behaviors across the entire application.
+
+## Overview
+
+Model provides definitions of types, interfaces, and structures that are shared between different components of the framework. It establishes a common vocabulary and ensures consistency in data handling throughout the system.
+
+## Main Components
+
+### Errors
+
+The `errors` subpackage provides a standardized structure for error handling in the Boost framework. It includes:
+
+- Custom error types for different scenarios
+- Functions for creating and manipulating errors
+- Utilities for formatting and presenting errors
+
+This component allows for consistent and informative error handling throughout the application.
+
+### RestResponse
+
+The `restresponse` subpackage defines structures for standardizing responses in REST APIs. It includes:
+
+- Models for success and error responses
+- Utilities for response formatting
+- Functions for conversion between different formats
+
+This component ensures consistency in API interfaces and facilitates integration with external clients.
+
+## How to Use
+
+To use the Model package in your application:
+
+1. Import the package or specific subpackage containing the desired structures
+2. Use the defined interfaces and structures in your code
+3. Extend the base structures when necessary for specific cases
+
+## Integration with Other Packages
+
+Model integrates with virtually all other components of the Boost framework:
+
+- Bootstrap: For defining initialization structures
+- Factory: For defining factory interfaces
+- Wrapper: For defining adapter interfaces
+- Extra: For defining middleware and health check structures
+
+## Extensibility
+
+The Model package was designed to be easily extensible. To add new structures or interfaces:
+
+1. Identify the appropriate subpackage or create a new one if necessary
+2. Define the new structures or interfaces following existing patterns
+3. Add appropriate documentation for the new definitions
+
+## Contribution
+
+Contributions to the Model package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,56 @@
+# Utils
+
+The Utils package provides a set of utilities and helper functions that are used throughout the Boost framework. This package contains general-purpose implementations that simplify common tasks and promote code reuse.
+
+## Overview
+
+Utils offers solutions for recurring problems in application development, such as collection manipulation, generic interfaces, and string processing. These implementations follow best practices and are optimized for performance and security.
+
+## Main Components
+
+### Collections
+
+The `collections` subpackage provides structures and functions for working with data collections, such as lists, maps, and sets. It includes efficient implementations for common collection operations, such as filtering, mapping, and reduction.
+
+These implementations are designed to be generic and reusable, allowing developers to work with collections of different types in a consistent and efficient manner.
+
+### Interfaces
+
+The `interfaces` subpackage defines generic interfaces that are used throughout the Boost framework. These interfaces establish clear contracts between components and promote code decoupling and testability.
+
+The interfaces defined in this package are carefully designed to be simple, cohesive, and extensible, following the principles of effective interface design.
+
+### Strings
+
+The `strings` subpackage offers functions for string manipulation and processing. It includes implementations for common operations such as formatting, validation, transformation, and string analysis.
+
+These functions are optimized for performance and security, and follow best practices for string handling in Go, including considerations for internationalization and character encoding.
+
+## How to Use
+
+To use the Utils package in your application:
+
+1. Import the specific subpackage that contains the desired functions or structures
+2. Use the functions or structures in your code as needed
+3. Combine different utilities to solve complex problems
+
+## Integration with Other Packages
+
+Utils is used by virtually all other components of the Boost framework:
+
+- Bootstrap: For helper functions during initialization
+- Factory: For collection manipulation and interfaces
+- Wrapper: For string processing and data manipulation
+- Model: For implementing common behaviors
+
+## Extensibility
+
+The Utils package was designed to be easily extensible. To add new utilities:
+
+1. Identify the appropriate subpackage or create a new one if necessary
+2. Implement the functions or structures following existing patterns
+3. Add appropriate tests and documentation
+
+## Contribution
+
+Contributions to the Utils package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.

--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -1,0 +1,77 @@
+# Wrapper
+
+The Wrapper package provides adapters and abstractions for external libraries, allowing standardized and flexible integration with the Boost framework. This package is essential for ensuring interoperability and consistency when using third-party libraries.
+
+## Overview
+
+Wrapper acts as an abstraction layer between application code and external libraries, offering consistent interfaces and facilitating the replacement of underlying implementations without affecting client code. This promotes code maintainability and testability.
+
+## Main Components
+
+### Cache
+
+The `cache` subpackage provides abstractions for caching systems, including:
+
+- **Codec**: Serializers and deserializers for different formats (binary, gob, json, string)
+- **Driver**: Implementations for different cache providers (Redis, BigCache, FreeCache)
+- **Plugins**: Extensions for additional cache functionalities
+
+This component allows efficient storage and retrieval of cached data, with support for multiple formats and backends.
+
+### Config
+
+The `config` subpackage offers a unified interface for application configuration, with support for:
+
+- Multiple configuration sources (files, environment variables, flags)
+- Different formats (YAML, JSON, ENV)
+- Value validation and transformation
+
+This facilitates configuration management across different environments and deployment scenarios.
+
+### Log
+
+The `log` subpackage provides abstractions for logging systems, with support for:
+
+- Multiple log levels (debug, info, warn, error)
+- Different output formats (text, JSON, CloudWatch)
+- Integration with popular libraries (Zap, Zerolog, Logrus)
+
+This component allows consistent and configurable recording of application events and information.
+
+### Publisher
+
+The `publisher` subpackage offers abstractions for message publishing/subscription systems, including:
+
+- Drivers for different providers (Google Cloud Pub/Sub, Kafka, NATS)
+- Middleware for message interception and modification
+- Utilities for monitoring and metrics
+
+This facilitates asynchronous communication between components and services.
+
+## How to Use
+
+To use the Wrapper package in your application:
+
+1. Import the specific subpackage containing the desired abstraction
+2. Configure the specific implementation you want to use
+3. Use the abstract interface in your code, independent of the underlying implementation
+
+## Integration with Other Packages
+
+Wrapper integrates with other components of the Boost framework:
+
+- Bootstrap: For component initialization and configuration
+- Factory: For creating instances of specific implementations
+- Extra: For additional functionalities like middleware
+
+## Extensibility
+
+The Wrapper package was designed to be easily extensible. To add support for new libraries:
+
+1. Create a new subpackage in `contrib` with the name of the library
+2. Implement the necessary abstract interfaces
+3. Add appropriate tests and documentation
+
+## Contribution
+
+Contributions to the Wrapper package are welcome. When contributing, make sure to follow the code standards and add appropriate tests for new functionalities.


### PR DESCRIPTION
This PR adds English documentation for all main packages in the Boost framework, including:

- Main README with complete integration list and real usage example
- READMEs for bootstrap, examples, extra, factory, fx, model, utils, and wrapper packages

This improves accessibility for international users and provides clear documentation about the framework structure and capabilities.