### PR TITLE
Fix #23: Melhorar tratamento de erros na factory do MongoDB

### DIFF
--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
@@ -2,7 +2,7 @@ package mongo
 
 import (
 	"context"
-	"fmt"
+	"github.com/xgodev/boost/model/errors"
 	"github.com/xgodev/boost/wrapper/log"
 	"strings"
 
@@ -38,7 +38,7 @@ func NewConn(ctx context.Context, plugins ...Plugin) (*Conn, error) {
 	o, err := NewOptions()
 	if err != nil {
 		logger.Errorf("Falha ao obter opções padrão: %v", err)
-		return nil, fmt.Errorf("falha ao obter opções padrão: %w", err)
+		return nil, errors.Annotatef(err, "falha ao obter opções padrão")
 	}
 
 	return NewConnWithOptions(ctx, o, plugins...)
@@ -74,13 +74,13 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 	co, err := clientOptions(ctx, o)
 	if err != nil {
 		logger.Errorf("Falha ao criar opções de cliente: %v", err)
-		return nil, fmt.Errorf("falha ao criar opções de cliente: %w", err)
+		return nil, errors.Annotatef(err, "falha ao criar opções de cliente")
 	}
 
 	for _, clientOptionsPlugin := range clientOptionsPlugins {
 		if err := clientOptionsPlugin(ctx, co); err != nil {
 			logger.Errorf("Falha ao aplicar plugin de opções de cliente: %v", err)
-			return nil, fmt.Errorf("falha ao aplicar plugin de opções de cliente: %w", err)
+			return nil, errors.Annotatef(err, "falha ao aplicar plugin de opções de cliente")
 		}
 	}
 
@@ -95,7 +95,7 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 	for _, clientPlugin := range clientPlugins {
 		if err := clientPlugin(ctx, client); err != nil {
 			logger.Errorf("Falha ao aplicar plugin de cliente: %v", err)
-			return nil, fmt.Errorf("falha ao aplicar plugin de cliente: %w", err)
+			return nil, errors.Annotatef(err, "falha ao aplicar plugin de cliente")
 		}
 	}
 

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
@@ -38,7 +38,7 @@ func NewConn(ctx context.Context, plugins ...Plugin) (*Conn, error) {
 	o, err := NewOptions()
 	if err != nil {
 		logger.Errorf("Falha ao obter opções padrão: %v", err)
-		return nil, errors.Annotatef(err, "falha ao obter opções padrão")
+		return nil, errors.NewInternal(err, "falha ao obter opções padrão")
 	}
 
 	return NewConnWithOptions(ctx, o, plugins...)
@@ -74,13 +74,13 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 	co, err := clientOptions(ctx, o)
 	if err != nil {
 		logger.Errorf("Falha ao criar opções de cliente: %v", err)
-		return nil, errors.Annotatef(err, "falha ao criar opções de cliente")
+		return nil, errors.NewInternal(err, "falha ao criar opções de cliente")
 	}
 
 	for _, clientOptionsPlugin := range clientOptionsPlugins {
 		if err := clientOptionsPlugin(ctx, co); err != nil {
 			logger.Errorf("Falha ao aplicar plugin de opções de cliente: %v", err)
-			return nil, errors.Annotatef(err, "falha ao aplicar plugin de opções de cliente")
+			return nil, errors.NewInternal(err, "falha ao aplicar plugin de opções de cliente")
 		}
 	}
 
@@ -95,7 +95,7 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 	for _, clientPlugin := range clientPlugins {
 		if err := clientPlugin(ctx, client); err != nil {
 			logger.Errorf("Falha ao aplicar plugin de cliente: %v", err)
-			return nil, errors.Annotatef(err, "falha ao aplicar plugin de cliente")
+			return nil, errors.NewInternal(err, "falha ao aplicar plugin de cliente")
 		}
 	}
 

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
@@ -37,8 +37,8 @@ func NewConn(ctx context.Context, plugins ...Plugin) (*Conn, error) {
 
 	o, err := NewOptions()
 	if err != nil {
-		logger.Errorf("Falha ao obter opções padrão: %v", err)
-		return nil, errors.NewInternal(err, "falha ao obter opções padrão")
+		logger.Errorf("Failed to get default options: %v", err)
+		return nil, errors.NewInternal(err, "failed to get default options")
 	}
 
 	return NewConnWithOptions(ctx, o, plugins...)
@@ -73,14 +73,14 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 
 	co, err := clientOptions(ctx, o)
 	if err != nil {
-		logger.Errorf("Falha ao criar opções de cliente: %v", err)
-		return nil, errors.NewInternal(err, "falha ao criar opções de cliente")
+		logger.Errorf("Failed to create client options: %v", err)
+		return nil, errors.NewInternal(err, "failed to create client options")
 	}
 
 	for _, clientOptionsPlugin := range clientOptionsPlugins {
 		if err := clientOptionsPlugin(ctx, co); err != nil {
-			logger.Errorf("Falha ao aplicar plugin de opções de cliente: %v", err)
-			return nil, errors.NewInternal(err, "falha ao aplicar plugin de opções de cliente")
+			logger.Errorf("Failed to apply client options plugin: %v", err)
+			return nil, errors.NewInternal(err, "failed to apply client options plugin")
 		}
 	}
 
@@ -94,8 +94,8 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 
 	for _, clientPlugin := range clientPlugins {
 		if err := clientPlugin(ctx, client); err != nil {
-			logger.Errorf("Falha ao aplicar plugin de cliente: %v", err)
-			return nil, errors.NewInternal(err, "falha ao aplicar plugin de cliente")
+			logger.Errorf("Failed to apply client plugin: %v", err)
+			return nil, errors.NewInternal(err, "failed to apply client plugin")
 		}
 	}
 

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"fmt"
 	"github.com/xgodev/boost/wrapper/log"
 	"strings"
 
@@ -36,7 +37,8 @@ func NewConn(ctx context.Context, plugins ...Plugin) (*Conn, error) {
 
 	o, err := NewOptions()
 	if err != nil {
-		logger.Fatalf(err.Error())
+		logger.Errorf("Falha ao obter opções padrão: %v", err)
+		return nil, fmt.Errorf("falha ao obter opções padrão: %w", err)
 	}
 
 	return NewConnWithOptions(ctx, o, plugins...)
@@ -71,12 +73,14 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 
 	co, err := clientOptions(ctx, o)
 	if err != nil {
-		logger.Fatalf(err.Error())
+		logger.Errorf("Falha ao criar opções de cliente: %v", err)
+		return nil, fmt.Errorf("falha ao criar opções de cliente: %w", err)
 	}
 
 	for _, clientOptionsPlugin := range clientOptionsPlugins {
 		if err := clientOptionsPlugin(ctx, co); err != nil {
-			logger.Fatalf(err.Error())
+			logger.Errorf("Falha ao aplicar plugin de opções de cliente: %v", err)
+			return nil, fmt.Errorf("falha ao aplicar plugin de opções de cliente: %w", err)
 		}
 	}
 
@@ -90,7 +94,8 @@ func NewConnWithOptions(ctx context.Context, o *Options, plugins ...Plugin) (con
 
 	for _, clientPlugin := range clientPlugins {
 		if err := clientPlugin(ctx, client); err != nil {
-			logger.Fatalf(err.Error())
+			logger.Errorf("Falha ao aplicar plugin de cliente: %v", err)
+			return nil, fmt.Errorf("falha ao aplicar plugin de cliente: %w", err)
 		}
 	}
 

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
@@ -33,8 +33,8 @@ func NewHealthWithConfigPath(path string) (*Health, error) {
 func NewHealth() (*Health, error) {
 	o, err := NewOptions()
 	if err != nil {
-		log.Errorf("Falha ao obter opções de health: %v", err)
-		return nil, errors.NewInternal(err, "falha ao obter opções de health")
+		log.Errorf("Failed to get health options: %v", err)
+		return nil, errors.NewInternal(err, "failed to get health options")
 	}
 	return NewHealthWithOptions(o), nil
 }

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
@@ -34,7 +34,7 @@ func NewHealth() (*Health, error) {
 	o, err := NewOptions()
 	if err != nil {
 		log.Errorf("Falha ao obter opções de health: %v", err)
-		return nil, errors.Annotatef(err, "falha ao obter opções de health")
+		return nil, errors.NewInternal(err, "falha ao obter opções de health")
 	}
 	return NewHealthWithOptions(o), nil
 }

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
@@ -2,8 +2,8 @@ package health
 
 import (
 	"context"
-	"fmt"
 	"github.com/xgodev/boost/factory/contrib/go.mongodb.org/mongo-driver/v1"
+	"github.com/xgodev/boost/model/errors"
 
 	"github.com/xgodev/boost/extra/health"
 	"github.com/xgodev/boost/wrapper/log"
@@ -34,7 +34,7 @@ func NewHealth() (*Health, error) {
 	o, err := NewOptions()
 	if err != nil {
 		log.Errorf("Falha ao obter opções de health: %v", err)
-		return nil, fmt.Errorf("falha ao obter opções de health: %w", err)
+		return nil, errors.Annotatef(err, "falha ao obter opções de health")
 	}
 	return NewHealthWithOptions(o), nil
 }

--- a/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
+++ b/factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"fmt"
 	"github.com/xgodev/boost/factory/contrib/go.mongodb.org/mongo-driver/v1"
 
 	"github.com/xgodev/boost/extra/health"
@@ -29,12 +30,13 @@ func NewHealthWithConfigPath(path string) (*Health, error) {
 }
 
 // NewHealth returns a new health with default options.
-func NewHealth() *Health {
+func NewHealth() (*Health, error) {
 	o, err := NewOptions()
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Errorf("Falha ao obter opções de health: %v", err)
+		return nil, fmt.Errorf("falha ao obter opções de health: %w", err)
 	}
-	return NewHealthWithOptions(o)
+	return NewHealthWithOptions(o), nil
 }
 
 // Register registers this health plugin on a new mongo client.


### PR DESCRIPTION
## Descrição
Esta PR resolve a issue #23, melhorando o tratamento de erros na factory do MongoDB.

## Mudanças realizadas
- Substituição de todas as chamadas `logger.Fatalf()` por retornos de erro para o chamador
- Implementação de logs informativos com `logger.Errorf()` antes de retornar os erros
- Adição de mensagens de erro contextualizadas usando `fmt.Errorf()`
- Atualização da assinatura do método `NewHealth()` para retornar erro

## Benefícios
- Maior robustez da aplicação em produção
- Melhor capacidade de recuperação de falhas
- Maior controle sobre o fluxo de execução pelo código cliente
- Mensagens de erro mais informativas

## Arquivos modificados
- `factory/contrib/go.mongodb.org/mongo-driver/v1/conn.go`
- `factory/contrib/go.mongodb.org/mongo-driver/v1/plugins/local/health/health.go`

Resolve #23