### PR TITLE
Add context to application

### DIFF
--- a/bootstrap/function/function.go
+++ b/bootstrap/function/function.go
@@ -2,11 +2,12 @@ package function
 
 import (
 	"context"
+	"os"
+
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/xgodev/boost/extra/middleware"
 	"github.com/xgodev/boost/factory/contrib/spf13/cobra/v1"
 	"github.com/xgodev/boost/model/errors"
-	"os"
 
 	co "github.com/spf13/cobra"
 )
@@ -56,5 +57,5 @@ func (f *Function[T]) Run(ctx context.Context, fn Handler[T], c ...CmdFunc[T]) e
 		}
 	}
 
-	return cobra.Run(rootCmd, cmds...)
+	return cobra.RunContext(ctx, rootCmd, cmds...)
 }

--- a/factory/contrib/go-resty/resty/v2/examples/cobra/main.go
+++ b/factory/contrib/go-resty/resty/v2/examples/cobra/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
+	"os"
+
 	"github.com/xgodev/boost"
 	log2 "github.com/xgodev/boost/factory/contrib/go-resty/resty/v2/plugins/local/wrapper/log"
 	c "github.com/xgodev/boost/factory/contrib/spf13/cobra/v1"
-	"os"
 
 	r "github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
@@ -72,7 +73,7 @@ func main() {
 		Version: "1.0.0",
 	}
 
-	if err := c.Run(rootCMD, cmds...); err != nil {
+	if err := c.RunContext(ctx, rootCMD, cmds...); err != nil {
 		logger.Errorf(err.Error())
 	}
 

--- a/factory/contrib/spf13/cobra/v1/cobra.go
+++ b/factory/contrib/spf13/cobra/v1/cobra.go
@@ -1,11 +1,13 @@
 package cobra
 
 import (
+	"context"
 	"fmt"
-	"github.com/xgodev/boost/wrapper/config"
-	"github.com/xgodev/boost/wrapper/config/model"
 	"net"
 	"time"
+
+	"github.com/xgodev/boost/wrapper/config"
+	"github.com/xgodev/boost/wrapper/config/model"
 
 	"github.com/spf13/cobra"
 	"github.com/xgodev/boost/wrapper/log"
@@ -34,6 +36,23 @@ func Run(rootCmd *cobra.Command, cmds ...*cobra.Command) error {
 	rootCmd.PersistentFlags().StringSlice(model.ConfArgument, nil, "path to one or more config files")
 
 	return rootCmd.Execute()
+}
+
+// Run with context and uses the args and run through the command tree finding
+// appropriate matches for commands and then corresponding flags.
+func RunContext(ctx context.Context, rootCmd *cobra.Command, cmds ...*cobra.Command) error {
+
+	rootCmd.AddCommand(cmds...)
+
+	rootCmd.DisableFlagParsing = true
+
+	for _, entry := range config.Entries() {
+		parseFlag(rootCmd, entry)
+	}
+
+	rootCmd.PersistentFlags().StringSlice(model.ConfArgument, nil, "path to one or more config files")
+
+	return rootCmd.ExecuteContext(ctx)
 }
 
 func parseFlag(cmd *cobra.Command, c config.Config) { // nolint

--- a/fx/modules/extra/multiserver/module.go
+++ b/fx/modules/extra/multiserver/module.go
@@ -2,9 +2,10 @@ package multiserver
 
 import (
 	"context"
+	"sync"
+
 	"github.com/xgodev/boost/factory/contrib/spf13/cobra/v1"
 	contextfx "github.com/xgodev/boost/fx/modules/core/context"
-	"sync"
 
 	c "github.com/spf13/cobra"
 	server "github.com/xgodev/boost/extra/multiserver"
@@ -33,7 +34,8 @@ func Module() fx.Option {
 			fx.Invoke(
 				func(ctx context.Context, p params) error {
 
-					return cobra.Run(
+					return cobra.RunContext(
+						ctx,
 						&c.Command{
 							Run: func(cmd *c.Command, args []string) {
 								server.Serve(ctx, p.Servers...)


### PR DESCRIPTION
This pull request introduces the `RunContext` method, which allows running the application with a context.  
It enables proper cancellation support for Cobra commands, improving control over command execution and graceful termination.
