### PR TITLE
docs: CLAUDE.md + dev workflow (gitflow, quality-gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# boost — Claude Code
+
+Framework modular e extensível para serviços Go (`github.com/xgodev/boost`):
+boot único (`boost.Start`), config/log/cache/publisher como wrappers, e uma
+factory por componente sob `factory/contrib/`.
+
+## Iron Laws — NUNCA violar
+
+1. **`boost.Start()` primeiro.** Config e logger só existem depois dele.
+   Nada de `config`/`log` antes do `Start`.
+2. **Log só via `wrapper/log`.** `log.FromContext(ctx)` — nunca
+   `zap.NewProduction()`, `zerolog.New()`, `logrus.New()` em código de app.
+3. **Config só via `wrapper/config`.** Nada de `os.Getenv`/viper direto fora
+   do `config.Add` em `init()`. Namespacing `boost.factory.<x>.*`.
+4. **Uma factory por componente, via construtor da factory.** Nunca instanciar
+   o SDK upstream direto — use `factory/contrib/<x>`.
+5. **Compatibilidade retroativa.** API pública de um componente não quebra sem
+   bump de major e justificativa. Mudança observável → teste antes.
+6. **O plugin `golang-boost` co-evolui com o código.** Mudou um componente →
+   atualize a skill correspondente em `skills/boost-*` no mesmo PR. Skill nova
+   para componente novo. Versão do plugin sobe (`.claude-plugin/plugin.json`)
+   quando o conteúdo muda — sem bump, auto-update não reconhece.
+
+### Red flags — PARAR e reportar
+
+- SDK upstream instanciado direto (sem passar pela factory)
+- `os.Getenv` / logger de terceiro fora do wrapper
+- API pública alterada sem teste e sem nota de compat
+- Componente tocado sem a skill `boost-*` correspondente atualizada
+- `git push` sem quality-gate verde
+- Issue ou PR ausentes (ver `docs/development/gitflow.md`)
+
+## Regras gerais de código
+
+- **`gofmt`/`goimports` limpo. `go vet` e linter sem warning.**
+- **`go build ./...` e `go test ./...` verdes** antes de qualquer push.
+- **Single source of truth** — config keys e defaults declarados uma vez no
+  `config.go` do componente.
+- **Separação de concerns** — factory constrói, wrapper abstrai, app consome.
+- Documentação é parte da tarefa: mudou componente/config key/comportamento →
+  atualizar README do pacote **e** a skill `boost-*` no mesmo commit.
+- Teste valida comportamento, não só cobre linha. Bug fix → teste vermelho
+  primeiro (TDD).
+
+## Skills do plugin (este repo É o plugin)
+
+- `skills/boost-*` — skills de **consumo** (como usar boost). Distribuídas no
+  plugin `golang-boost`.
+- `.claude/skills/*` — skills **internas** do projeto (manutenção). Não fazem
+  parte do plugin.
+- `skills/boost-maintainer` — guia de manutenção (criar nova factory/skill).
+  Leia antes de adicionar componente.
+
+## Referências (ler quando precisar)
+
+| Doc | Quando |
+|---|---|
+| `docs/development/gitflow.md` | Issue, branch, commit, PR, fechamento |
+| `docs/development/quality-gate.md` | Gate comparativo antes do push |
+| `skills/boost-maintainer/SKILL.md` | Adicionar factory/componente/skill |
+| `skills/boost-start/SKILL.md` | Sequência de boot |
+| `skills/boost-wrapper-log/SKILL.md` | Logging via wrapper |
+| `skills/boost-wrapper-config/SKILL.md` | Config namespacing |
+| README de cada pacote (`factory/`, `wrapper/`, `bootstrap/`, …) | API do componente |

--- a/docs/development/gitflow.md
+++ b/docs/development/gitflow.md
@@ -1,0 +1,54 @@
+# Gitflow — boost
+
+```
+Issue → Branch (de develop) → Commits → PR → Review/Merge
+```
+
+| Branch | Propósito | Merge into |
+|---|---|---|
+| `main` | Releases | — |
+| `develop` | Próxima release | `main` |
+| `feature/*` | Funcionalidades | `develop` |
+| `bugfix/*` | Correções | `develop` |
+| `hotfix/*` | Urgências em produção | `main` + `develop` |
+| `release/*` | Preparação de release | `main` + `develop` |
+
+## Regras
+
+1. **Issue sempre, primeiro.** Toda mudança (feature/bug/docs) tem issue no
+   GitHub antes de qualquer código. `gh issue list --search` antes de criar
+   (evita duplicata). Label apropriada (`documentation`, `bug`, `enhancement`).
+2. **PR sempre.** Nada commitado direto em `develop` ou `main`. Toda mudança
+   entra por Pull Request — sem exceção.
+3. **Nome de branch: `feature/{N}-slug` / `bugfix/{N}-slug`** (`{N}` = número
+   da issue) — convenção já em uso no repo. Antes de criar:
+   `git fetch && git branch -a | grep {N}-`.
+4. **A partir de `develop` atualizado**: `git checkout develop && git pull --ff-only`.
+5. **Mergear `develop` antes de trabalho longo**: `git merge origin/develop`.
+6. Commits em **inglês**, foco no **"why"**, **sem `Co-Authored-By`**.
+7. **NUNCA `Closes #N` / `Fixes #N`** em commits — fechamento é manual e só a
+   pedido do usuário.
+8. **NUNCA rebase.** Sempre `git merge`, nunca `git pull --rebase`.
+9. **Quality gate verde é pré-requisito de qualquer `git push`.** Ver
+   [`quality-gate.md`](quality-gate.md). Vermelho → corrige a causa raiz →
+   roda de novo → só então push.
+10. **Push após cada commit lógico** (depois do gate verde). Bugfix/hotfix
+    mergeia rápido; feature aguarda review. **Nunca mergear feature→develop
+    sem o usuário pedir.**
+
+## Rastreabilidade — comentários na issue
+
+A issue é o log de auditoria. Comentar em: plano antes de começar; cada push
+(hash + arquivos + build/teste); mudança de plano; problema com evidência;
+análise técnica; merge; resumo final. Opções A/B/C ao usuário vão na issue
+**antes** da pergunta.
+
+## Fechar issue
+
+Só quando o usuário pedir. `gh issue close <N>` — sem auto-close via commit.
+
+## Labels que excluem das release notes
+
+- `duplicate` — escopo idêntico a outra issue (a duplicata é a mais nova).
+- `documentation` quando puramente interno (CI/CD, scripts, planejamento) —
+  use também `wontfix`/critério do mantenedor para não vazar em notas.

--- a/docs/development/quality-gate.md
+++ b/docs/development/quality-gate.md
@@ -1,0 +1,94 @@
+# Quality Gate — boost
+
+boost usa o gate **comparativo compartilhado**
+[`github.com/xgodev/quality-gate`](https://github.com/xgodev/quality-gate),
+igual ao OpenRig e demais projetos xgodev. Filosofia: o gate quebra quando o
+PR **piora** uma métrica vs a base (`develop`). Dívida preexistente nunca
+bloqueia — cada PR pode reduzir, nunca aumentar.
+
+> Canônico de uso/contrato: `~/.quality-gate/docs/` após clonar.
+
+## TL;DR
+
+```bash
+# primeira vez (clona) — depois, manter atualizado:
+git -C ~/.quality-gate pull --ff-only \
+  || git clone --depth 1 https://github.com/xgodev/quality-gate.git ~/.quality-gate
+
+~/.quality-gate/qg --base origin/develop
+```
+
+Vermelho → arrumar a **causa raiz** do que regrediu → rodar de novo → só
+então `git push`.
+
+### Agentes (Claude Code)
+
+Use o **plugin/skill `quality-gate`** — ele clona/atualiza o gate, roda o
+dispatcher e interpreta o JSON. Triggers: "rodar quality gate", "rodar QG",
+"verificar qualidade", "validar antes do PR", "qa antes do push" (e
+equivalentes em EN). É **pré-requisito de qualquer push** (regra 9 do
+[`gitflow.md`](gitflow.md)).
+
+## Métricas comparadas (PR vs base) — Go
+
+O gate auto-detecta Go e compara, contra `origin/develop`:
+
+| Métrica | Como conta |
+|---|---|
+| `fmt` | `gofmt`/`goimports` (rulesets embutidos do gate) |
+| `lint` | `go vet` + linter sem warning |
+| `build` | `go build ./...` |
+| `test` | `go test ./...` (soma de falhas) |
+| `complexity` | thresholds default do gate |
+| `coverage` | `go test -cover` → `% linhas`, margem `QG_COV_MARGIN` |
+
+> O gate **ignora de propósito** configs de lint/fmt do projeto
+> (tamper-resistance) e usa rulesets próprios. Configs locais do repo só
+> valem para execução manual local.
+
+## Local vs CI — mesmo dispatcher
+
+| Aspecto | Local | CI |
+|---|---|---|
+| Comando | `~/.quality-gate/qg --base origin/develop` | mesmo `qg`, clonado no job |
+| Baseline | `git archive origin/develop` (cache `/tmp`) | `--baseline-dir` + `--force-full` |
+| Falha no CI | — | sticky comment + `request-changes` automático no PR |
+
+## Exit codes
+
+| Código | Significado |
+|---|---|
+| 0 | Passou / bypass / sem linguagem suportada relevante |
+| 1 | Regrediu ≥1 métrica vs base |
+| 2 | Erro de ferramenta/setup (NÃO é regressão — relatar stderr) |
+| 3 | Nenhuma linguagem suportada detectada |
+
+## Env vars (prefixo `QG_`)
+
+| Variável | Default | Uso |
+|---|---|---|
+| `QG_BASE_REF` | (vazio) | = `--base`. Vazio → modo absoluto |
+| `QG_BASELINE_DIR` | (vazio) | = `--baseline-dir` (CI) |
+| `QG_COV_MARGIN` | `1.0` | Tolerância (pp) de coverage |
+| `QG_FORMAT` | `text` | `text` ou `json` |
+| `QG_BYPASS_REASON` | (vazio) | **NUNCA setar por conta própria.** Força exit 0 + audit log |
+
+## Validação de negócio — testes obrigatórios
+
+Cobertura sozinha não basta. Lógica nova/alterada **exige teste que valide
+comportamento esperado**, não só execute o caminho.
+
+- Bug fix → teste vermelho que reproduz o bug primeiro, fix depois (TDD).
+- Feature → teste do cenário esperado **e** edge cases.
+- Refactor com comportamento observável alterado → teste antes.
+
+## Forbidden
+
+Pra silenciar o gate sem fix real:
+
+- `QG_BYPASS_REASON` por iniciativa própria.
+- Editar código/teste/config só pra "passar".
+- Marcar testes como `t.Skip` / build tags pra esconder falha.
+- `--no-verify` no commit.
+
+A regra: **causa raiz ou escalar.**


### PR DESCRIPTION
Closes the work for #39.

## What

- `CLAUDE.md` (raiz) — visão do boost, **Iron Laws**, regras gerais Go, tabela de referências.
- `docs/development/gitflow.md` — Issue → Branch (de `develop`) → Commits → PR → Review/Merge. **Issue sempre, PR sempre**, sem rebase, commits em inglês focados no "why", gate verde pré-push.
- `docs/development/quality-gate.md` — gate comparativo compartilhado `xgodev/quality-gate` via plugin/skill `quality-gate`; métricas Go, exit codes, forbidden.

## Premissas atendidas

- ✅ Issue criada primeiro (#39)
- ✅ Branch de `develop`, nome `feature/{N}-slug` (convenção do repo)
- ✅ PR (este) — nada direto em develop/main
- ✅ Quality-gate rodado antes do push (verde — docs-only, gate skipou Go)
- ✅ Padrão idêntico ao OpenRig

## Escopo

Apenas documentação. Zero mudança de código de produção.

Ref #39