### PR TITLE
feat(errors): registry de erros customizados → código HTTP/gRPC (ou ignore)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "golang-boost",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Component-aligned Claude Code skill bundle for github.com/xgodev/boost. One plugin, one skill per boost component (56 total): boot sequence, log/config/publisher/cache wrappers, model/errors, every factory under factory/contrib/ (Echo, Resty, Pub/Sub, Mongo, Cassandra, Redis, Elasticsearch, Kafka, AWS, gRPC, gocloud.dev, Postgres, Oracle, BigQuery, Firestore, BuntDB, MemDB, BigCache, FreeCache, Vault, Hystrix, Ants, NATS, Goka, CloudEvents, GCP API/gRPC composition, OTel, Datadog, Prometheus, fx, Cobra, GraphQL, K8s, FTP, HTTP/2, Zap/Zerolog/Logrus loggers), function bootstrap + Pub/Sub/NATS/Kafka adapters, middleware stack, extra middleware/health/multiserver, fx modules, and a maintainer guide. Each skill cites the boost source paths it teaches; factory skills with framework-shipped examples cite them.",
   "author": {
     "name": "João Paulo Faria",

--- a/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go
+++ b/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/xgodev/boost/bootstrap/function"
 	"github.com/xgodev/boost/model/errors"
+	response "github.com/xgodev/boost/model/restresponse"
 	"github.com/xgodev/boost/wrapper/log"
 	"net/http"
 )
@@ -48,6 +49,9 @@ func Wrapper[T any](fn function.Handler[T]) func(context.Context, ce.Event) ce.R
 	return func(ctx context.Context, event ce.Event) ce.Result {
 		e, err := fn(ctx, event)
 		if err != nil {
+			if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+				return ce.NewHTTPResult(http.StatusOK, "")
+			}
 			status := ErrorStatusCode(err)
 			return ce.NewHTTPResult(status, err.Error())
 		}
@@ -76,32 +80,10 @@ func Wrapper[T any](fn function.Handler[T]) func(context.Context, ce.Event) ce.R
 	}
 }
 
-// ErrorStatusCode translates to the respective status code.
+// ErrorStatusCode translates err to the respective HTTP status code.
 func ErrorStatusCode(err error) int {
-
-	switch {
-	case errors.IsNotFound(err):
-		return http.StatusNotFound
-	case errors.IsMethodNotAllowed(err):
-		return http.StatusMethodNotAllowed
-	case errors.IsNotValid(err) || errors.IsBadRequest(err):
-		return http.StatusBadRequest
-	case errors.IsServiceUnavailable(err):
-		return http.StatusServiceUnavailable
-	case errors.IsConflict(err) || errors.IsAlreadyExists(err):
-		return http.StatusConflict
-	case errors.IsNotImplemented(err) || errors.IsNotProvisioned(err):
-		return http.StatusNotImplemented
-	case errors.IsUnauthorized(err):
-		return http.StatusUnauthorized
-	case errors.IsForbidden(err):
-		return http.StatusForbidden
-	case errors.IsNotSupported(err) || errors.IsNotAssigned(err):
+	if _, ok := err.(validator.ValidationErrors); ok {
 		return http.StatusUnprocessableEntity
-	default:
-		if _, ok := err.(validator.ValidationErrors); ok {
-			return http.StatusUnprocessableEntity
-		}
-		return http.StatusInternalServerError
 	}
+	return response.HTTPStatusFor(errors.Classify(err))
 }

--- a/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go
+++ b/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go
@@ -12,6 +12,7 @@ type customForbidden struct{ msg string }
 func (c *customForbidden) Error() string { return c.msg }
 
 func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	defer errors.ResetRegistry()
 	errors.RegisterMatch(func(err error) bool {
 		_, ok := err.(*customForbidden)
 		return ok

--- a/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go
+++ b/bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go
@@ -1,0 +1,29 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+type customForbidden struct{ msg string }
+
+func (c *customForbidden) Error() string { return c.msg }
+
+func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customForbidden)
+		return ok
+	}, errors.KindForbidden)
+
+	if got := ErrorStatusCode(&customForbidden{"no"}); got != http.StatusForbidden {
+		t.Fatalf("ErrorStatusCode = %d, want 403", got)
+	}
+}
+
+func TestErrorStatusCode_BuiltinNotFound(t *testing.T) {
+	if ErrorStatusCode(errors.NotFoundf("x")) != http.StatusNotFound {
+		t.Fatal("builtin NotFound not mapped to 404")
+	}
+}

--- a/docs/superpowers/plans/2026-06-01-error-registry.md
+++ b/docs/superpowers/plans/2026-06-01-error-registry.md
@@ -1,0 +1,1087 @@
+# Error Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que a aplicação registre erros customizados, associando-os a um semântico boost (`Kind`) que resolve código HTTP e gRPC nos 3 transportes, ou marcando-os para ignorar.
+
+**Architecture:** Um registry global em `model/errors` mapeia matchers (sentinela via `errors.Is`, ou predicado via `errors.As`) para um `Kind` semântico — sem importar `net/http` nem `grpc/codes`. `Classify(err) Kind` resolve com precedência: registrados → `Is*` embutido → `KindInternal`. As tabelas `Kind → código` ficam na borda de cada transporte (HTTP compartilhada em `restresponse`, gRPC no pacote server). Ignore é configurável por erro (`AsSuccess` e/ou `SilenceLog`).
+
+**Tech Stack:** Go 1.26, testify/suite, labstack/echo v4, google.golang.org/grpc, cloudevents/sdk-go v2.
+
+---
+
+## File Structure
+
+Novos:
+- `model/errors/kind.go` — enum `Kind` + `builtinKind(err) Kind` (mapeia `Is*` → `Kind`).
+- `model/errors/registry.go` — registry global, `Register`/`RegisterMatch`/`Classify`, `Ignore`/`IgnoreMatch`/`IgnoreOf`, `IgnoreOption`.
+- `model/errors/kind_test.go`, `model/errors/registry_test.go`.
+
+Alterados:
+- `model/restresponse/status_code.go` (novo arquivo no pacote `response`) — `HTTPStatusFor(errors.Kind) int`.
+- `factory/contrib/labstack/echo/v4/error_handler.go` — `ErrorStatusCode` via `Classify`; honrar `IgnoreAsSuccess`.
+- `factory/contrib/google.golang.org/grpc/v1/server/error.go` — `Error` via `Classify`; honrar `IgnoreAsSuccess`.
+- `bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go` — `ErrorStatusCode` via `Classify`; honrar `IgnoreAsSuccess`.
+- `factory/contrib/labstack/echo/v4/plugins/local/wrapper/log/log.go` — `IgnoreSilenceLog` baixa nível.
+- `factory/contrib/google.golang.org/grpc/v1/server/plugins/local/wrapper/log/log.go` — `IgnoreSilenceLog` omite campo `error` e baixa nível.
+- Skills + READMEs + `.claude-plugin/plugin.json` (bump).
+
+**Comportamento preservado:** `validator.ValidationErrors` continua tratado em cada transporte (HTTP 422 / gRPC InvalidArgument), fora do `Classify` (model/errors não importa validator). Todos os `Is*` ficam inalterados.
+
+**Gap fechado de brinde:** `KindTimeout` (HTTP 408 / gRPC DeadlineExceeded) e `KindTooManyRequests` (HTTP 429 / gRPC ResourceExhausted) — antes caíam em 500/Internal.
+
+---
+
+## Task 1: Enum `Kind` + classificação embutida
+
+**Files:**
+- Create: `model/errors/kind.go`
+- Test: `model/errors/kind_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package errors
+
+import "testing"
+
+func TestBuiltinKind(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want Kind
+	}{
+		{"notfound", NotFoundf("x"), KindNotFound},
+		{"badrequest", BadRequestf("x"), KindBadRequest},
+		{"notvalid", NotValidf("x"), KindNotValid},
+		{"conflict", Conflictf("x"), KindConflict},
+		{"alreadyexists", AlreadyExistsf("x"), KindAlreadyExists},
+		{"forbidden", Forbiddenf("x"), KindForbidden},
+		{"unauthorized", Unauthorizedf("x"), KindUnauthorized},
+		{"serviceunavailable", ServiceUnavailablef("x"), KindServiceUnavailable},
+		{"notimplemented", NotImplementedf("x"), KindNotImplemented},
+		{"notprovisioned", NotProvisionedf("x"), KindNotProvisioned},
+		{"notsupported", NotSupportedf("x"), KindNotSupported},
+		{"notassigned", NotAssignedf("x"), KindNotAssigned},
+		{"methodnotallowed", MethodNotAllowedf("x"), KindMethodNotAllowed},
+		{"toomanyrequests", TooManyRequestsf("x"), KindTooManyRequests},
+		{"timeout", Timeoutf("x"), KindTimeout},
+		{"internal", Internalf("x"), KindInternal},
+		{"plain", New("x"), KindInternal},
+	}
+	for _, c := range cases {
+		if got := builtinKind(c.err); got != c.want {
+			t.Errorf("%s: builtinKind = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+```
+
+> Antes de escrever o teste, confirme os nomes exatos dos construtores `*f`
+> em `model/errors/*.go` (ex.: `grep -rn "^func .*f(format" model/errors`).
+> Ajuste o teste se algum construtor tiver assinatura diferente.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./model/errors/ -run TestBuiltinKind -v`
+Expected: FAIL — `undefined: Kind` / `undefined: builtinKind`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+package errors
+
+// Kind is a transport-agnostic semantic classification of an error.
+// Each Kind mirrors a category in the boost error catalog and is resolved
+// to a concrete HTTP status / gRPC code at the transport boundary.
+type Kind int
+
+const (
+	// KindInternal is the default/fallback classification.
+	KindInternal Kind = iota
+	KindNotFound
+	KindBadRequest
+	KindNotValid
+	KindConflict
+	KindAlreadyExists
+	KindForbidden
+	KindUnauthorized
+	KindServiceUnavailable
+	KindNotImplemented
+	KindNotProvisioned
+	KindNotSupported
+	KindNotAssigned
+	KindMethodNotAllowed
+	KindTooManyRequests
+	KindTimeout
+)
+
+// builtinKind classifies err using the built-in Is* catalog checks.
+// Returns KindInternal when no boost type matches.
+func builtinKind(err error) Kind {
+	switch {
+	case IsNotFound(err):
+		return KindNotFound
+	case IsMethodNotAllowed(err):
+		return KindMethodNotAllowed
+	case IsNotValid(err):
+		return KindNotValid
+	case IsBadRequest(err):
+		return KindBadRequest
+	case IsServiceUnavailable(err):
+		return KindServiceUnavailable
+	case IsConflict(err):
+		return KindConflict
+	case IsAlreadyExists(err):
+		return KindAlreadyExists
+	case IsNotImplemented(err):
+		return KindNotImplemented
+	case IsNotProvisioned(err):
+		return KindNotProvisioned
+	case IsUnauthorized(err):
+		return KindUnauthorized
+	case IsForbidden(err):
+		return KindForbidden
+	case IsNotSupported(err):
+		return KindNotSupported
+	case IsNotAssigned(err):
+		return KindNotAssigned
+	case IsTooManyRequests(err):
+		return KindTooManyRequests
+	case IsTimeout(err):
+		return KindTimeout
+	default:
+		return KindInternal
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./model/errors/ -run TestBuiltinKind -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add model/errors/kind.go model/errors/kind_test.go
+git commit -m "feat(errors): add Kind enum and builtin classification"
+```
+
+---
+
+## Task 2: Registry de classificação (`Register`/`RegisterMatch`/`Classify`)
+
+**Files:**
+- Create: `model/errors/registry.go`
+- Test: `model/errors/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package errors
+
+import (
+	stderrors "errors"
+	"testing"
+)
+
+type xptoError struct{ msg string }
+
+func (e *xptoError) Error() string { return e.msg }
+
+func TestClassifyRegisteredSentinel(t *testing.T) {
+	defer resetRegistry()
+	sentinel := New("sentinel boom")
+	Register(sentinel, KindNotFound)
+
+	if got := Classify(sentinel); got != KindNotFound {
+		t.Fatalf("Classify = %v, want KindNotFound", got)
+	}
+}
+
+func TestClassifyRegisteredMatch(t *testing.T) {
+	defer resetRegistry()
+	RegisterMatch(func(err error) bool {
+		var x *xptoError
+		return stderrors.As(err, &x)
+	}, KindNotFound)
+
+	if got := Classify(&xptoError{"boom"}); got != KindNotFound {
+		t.Fatalf("Classify = %v, want KindNotFound", got)
+	}
+}
+
+func TestClassifyFallsBackToBuiltin(t *testing.T) {
+	defer resetRegistry()
+	if got := Classify(NotFoundf("x")); got != KindNotFound {
+		t.Fatalf("Classify = %v, want KindNotFound", got)
+	}
+}
+
+func TestClassifyDefaultInternal(t *testing.T) {
+	defer resetRegistry()
+	if got := Classify(New("anything")); got != KindInternal {
+		t.Fatalf("Classify = %v, want KindInternal", got)
+	}
+}
+
+func TestClassifyRegisteredWinsOverBuiltin(t *testing.T) {
+	defer resetRegistry()
+	// A boost NotFound error, re-registered as Conflict, must classify as Conflict.
+	e := NotFoundf("x")
+	Register(e, KindConflict)
+	if got := Classify(e); got != KindConflict {
+		t.Fatalf("Classify = %v, want KindConflict", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./model/errors/ -run TestClassify -v`
+Expected: FAIL — `undefined: Register` / `resetRegistry`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+package errors
+
+import "sync"
+
+type matcher struct {
+	match func(error) bool
+	kind  Kind
+}
+
+var (
+	registryMu sync.RWMutex
+	matchers   []matcher
+)
+
+// Register associates target with kind. An error err is matched when
+// errors.Is(err, target) is true. Intended to be called during boot,
+// before serving requests.
+func Register(target error, kind Kind) {
+	RegisterMatch(func(err error) bool { return Is(err, target) }, kind)
+}
+
+// RegisterMatch associates a custom predicate with kind. Use this for
+// type-based matching (errors.As) or any arbitrary condition.
+func RegisterMatch(match func(error) bool, kind Kind) {
+	if match == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	matchers = append(matchers, matcher{match: match, kind: kind})
+}
+
+// Classify resolves err to a Kind. Precedence: registered matchers (in
+// registration order, first match wins) -> built-in Is* catalog ->
+// KindInternal.
+func Classify(err error) Kind {
+	if err == nil {
+		return KindInternal
+	}
+	registryMu.RLock()
+	for _, m := range matchers {
+		if m.match(err) {
+			registryMu.RUnlock()
+			return m.kind
+		}
+	}
+	registryMu.RUnlock()
+	return builtinKind(err)
+}
+
+// resetRegistry clears all registrations. Test-only helper.
+func resetRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	matchers = nil
+	ignores = nil
+}
+```
+
+> `resetRegistry` referencia `ignores`, definido na Task 3. Se rodar a Task 2
+> isolada antes da 3, troque temporariamente o corpo para `matchers = nil` e
+> reponha `ignores = nil` na Task 3.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./model/errors/ -run TestClassify -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add model/errors/registry.go model/errors/registry_test.go
+git commit -m "feat(errors): add custom error classification registry"
+```
+
+---
+
+## Task 3: Ignore configurável (`Ignore`/`IgnoreMatch`/`IgnoreOf`)
+
+**Files:**
+- Modify: `model/errors/registry.go`
+- Test: `model/errors/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestIgnoreDefaultBoth(t *testing.T) {
+	defer resetRegistry()
+	e := New("noise")
+	Ignore(e) // no opts == AsSuccess + SilenceLog
+
+	pol, ok := IgnoreOf(e)
+	if !ok {
+		t.Fatal("IgnoreOf: ok = false, want true")
+	}
+	if pol&IgnoreAsSuccess == 0 || pol&IgnoreSilenceLog == 0 {
+		t.Fatalf("IgnoreOf = %b, want both bits set", pol)
+	}
+}
+
+func TestIgnoreSilenceOnly(t *testing.T) {
+	defer resetRegistry()
+	e := New("quiet")
+	Ignore(e, IgnoreSilenceLog)
+
+	pol, ok := IgnoreOf(e)
+	if !ok || pol&IgnoreSilenceLog == 0 || pol&IgnoreAsSuccess != 0 {
+		t.Fatalf("IgnoreOf = %b ok=%v, want SilenceLog only", pol, ok)
+	}
+}
+
+func TestIgnoreOfUnregistered(t *testing.T) {
+	defer resetRegistry()
+	if _, ok := IgnoreOf(New("x")); ok {
+		t.Fatal("IgnoreOf: ok = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./model/errors/ -run TestIgnore -v`
+Expected: FAIL — `undefined: Ignore` / `IgnoreOf` / `IgnoreAsSuccess`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `model/errors/registry.go`:
+
+```go
+// IgnoreOption configures how an ignored error is handled. Combine bits.
+type IgnoreOption int
+
+const (
+	// IgnoreAsSuccess makes the transport respond with success
+	// (HTTP 200/204, gRPC codes.OK) instead of an error.
+	IgnoreAsSuccess IgnoreOption = 1 << iota
+	// IgnoreSilenceLog suppresses (or lowers) logging of the error.
+	IgnoreSilenceLog
+)
+
+type ignoreRule struct {
+	match  func(error) bool
+	policy IgnoreOption
+}
+
+var ignores []ignoreRule
+
+// Ignore marks errors matching target (via errors.Is) to be ignored.
+// With no options, the error is fully ignored (AsSuccess + SilenceLog).
+func Ignore(target error, opts ...IgnoreOption) {
+	IgnoreMatch(func(err error) bool { return Is(err, target) }, opts...)
+}
+
+// IgnoreMatch marks errors matching the predicate to be ignored.
+// With no options, the error is fully ignored (AsSuccess + SilenceLog).
+func IgnoreMatch(match func(error) bool, opts ...IgnoreOption) {
+	if match == nil {
+		return
+	}
+	var policy IgnoreOption
+	if len(opts) == 0 {
+		policy = IgnoreAsSuccess | IgnoreSilenceLog
+	} else {
+		for _, o := range opts {
+			policy |= o
+		}
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	ignores = append(ignores, ignoreRule{match: match, policy: policy})
+}
+
+// IgnoreOf returns the ignore policy for err, if any was registered.
+func IgnoreOf(err error) (IgnoreOption, bool) {
+	if err == nil {
+		return 0, false
+	}
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	for _, r := range ignores {
+		if r.match(err) {
+			return r.policy, true
+		}
+	}
+	return 0, false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./model/errors/ -run TestIgnore -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole package + commit**
+
+Run: `go test ./model/errors/...`
+Expected: PASS (todos os testes, inclusive os `Is*` existentes).
+
+```bash
+git add model/errors/registry.go model/errors/registry_test.go
+git commit -m "feat(errors): add configurable ignore policy registry"
+```
+
+---
+
+## Task 4: Tabela HTTP compartilhada (`restresponse.HTTPStatusFor`)
+
+**Files:**
+- Create: `model/restresponse/status_code.go`
+- Test: `model/restresponse/status_code_test.go`
+
+> Verifique antes que `model/restresponse` ainda não importe `model/errors`
+> e que `model/errors` não importe `restresponse` (sem ciclo). `model/errors`
+> só importa stdlib, então é seguro.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package response
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+func TestHTTPStatusFor(t *testing.T) {
+	cases := map[errors.Kind]int{
+		errors.KindNotFound:           http.StatusNotFound,
+		errors.KindMethodNotAllowed:   http.StatusMethodNotAllowed,
+		errors.KindNotValid:           http.StatusBadRequest,
+		errors.KindBadRequest:         http.StatusBadRequest,
+		errors.KindServiceUnavailable: http.StatusServiceUnavailable,
+		errors.KindConflict:           http.StatusConflict,
+		errors.KindAlreadyExists:      http.StatusConflict,
+		errors.KindNotImplemented:     http.StatusNotImplemented,
+		errors.KindNotProvisioned:     http.StatusNotImplemented,
+		errors.KindUnauthorized:       http.StatusUnauthorized,
+		errors.KindForbidden:          http.StatusForbidden,
+		errors.KindNotSupported:       http.StatusUnprocessableEntity,
+		errors.KindNotAssigned:        http.StatusUnprocessableEntity,
+		errors.KindTooManyRequests:    http.StatusTooManyRequests,
+		errors.KindTimeout:            http.StatusRequestTimeout,
+		errors.KindInternal:           http.StatusInternalServerError,
+	}
+	for kind, want := range cases {
+		if got := HTTPStatusFor(kind); got != want {
+			t.Errorf("HTTPStatusFor(%v) = %d, want %d", kind, got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./model/restresponse/ -run TestHTTPStatusFor -v`
+Expected: FAIL — `undefined: HTTPStatusFor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+package response
+
+import (
+	"net/http"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+// HTTPStatusFor maps a boost error Kind to its HTTP status code.
+func HTTPStatusFor(kind errors.Kind) int {
+	switch kind {
+	case errors.KindNotFound:
+		return http.StatusNotFound
+	case errors.KindMethodNotAllowed:
+		return http.StatusMethodNotAllowed
+	case errors.KindNotValid, errors.KindBadRequest:
+		return http.StatusBadRequest
+	case errors.KindServiceUnavailable:
+		return http.StatusServiceUnavailable
+	case errors.KindConflict, errors.KindAlreadyExists:
+		return http.StatusConflict
+	case errors.KindNotImplemented, errors.KindNotProvisioned:
+		return http.StatusNotImplemented
+	case errors.KindUnauthorized:
+		return http.StatusUnauthorized
+	case errors.KindForbidden:
+		return http.StatusForbidden
+	case errors.KindNotSupported, errors.KindNotAssigned:
+		return http.StatusUnprocessableEntity
+	case errors.KindTooManyRequests:
+		return http.StatusTooManyRequests
+	case errors.KindTimeout:
+		return http.StatusRequestTimeout
+	default:
+		return http.StatusInternalServerError
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./model/restresponse/ -run TestHTTPStatusFor -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add model/restresponse/status_code.go model/restresponse/status_code_test.go
+git commit -m "feat(restresponse): add Kind->HTTP status mapping"
+```
+
+---
+
+## Task 5: Refactor do error handler do Echo + IgnoreAsSuccess
+
+**Files:**
+- Modify: `factory/contrib/labstack/echo/v4/error_handler.go`
+- Test: `factory/contrib/labstack/echo/v4/error_handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	e "github.com/labstack/echo/v4"
+	"github.com/xgodev/boost/model/errors"
+)
+
+type customNotFound struct{ msg string }
+
+func (c *customNotFound) Error() string { return c.msg }
+
+func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customNotFound)
+		return ok
+	}, errors.KindNotFound)
+
+	if got := ErrorStatusCode(&customNotFound{"missing"}); got != http.StatusNotFound {
+		t.Fatalf("ErrorStatusCode = %d, want 404", got)
+	}
+}
+
+func TestErrorHandler_IgnoreAsSuccess(t *testing.T) {
+	sentinel := errors.New("ignorable")
+	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
+
+	rec := httptest.NewRecorder()
+	srv := e.New()
+	c := srv.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+
+	errorHandler(sentinel, c, e.MIMEApplicationJSON)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./factory/contrib/labstack/echo/v4/ -run TestErrorStatusCode_RegisteredCustom -v`
+Expected: FAIL — comportamento atual retorna 500 para `*customNotFound`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Substitua o corpo de `errorHandler` e `ErrorStatusCode` em `error_handler.go`
+(mantendo imports `net/http`, `strconv`, validator, `response`; adicione o
+import do pacote errors caso ainda não exista):
+
+```go
+func errorHandler(err error, c e.Context, contentType string) {
+	// Ignored-as-success errors short-circuit to a success response.
+	if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+		if er := c.NoContent(http.StatusOK); er != nil {
+			c.Logger().Error(er)
+		}
+		return
+	}
+
+	var (
+		status  int
+		message string
+	)
+	if echoErr, ok := err.(*e.HTTPError); ok {
+		status = echoErr.Code
+		message = fmt.Sprintf("%v", echoErr.Message)
+	} else {
+		status = ErrorStatusCode(err)
+		message = err.Error()
+	}
+
+	var er error
+	if c.Request().Method == http.MethodHead {
+		er = c.NoContent(status)
+	} else {
+		switch contentType {
+		case e.MIMEApplicationJSON:
+			er = c.JSON(status, response.Error{HttpStatusCode: status, ErrorCode: strconv.Itoa(status), Message: message})
+		default:
+			er = c.String(status, message)
+		}
+	}
+	if er != nil {
+		c.Logger().Error(er)
+	}
+}
+
+// ErrorStatusCode translates err to the respective HTTP status code.
+func ErrorStatusCode(err error) int {
+	if _, ok := err.(validator.ValidationErrors); ok {
+		return http.StatusUnprocessableEntity
+	}
+	return response.HTTPStatusFor(errors.Classify(err))
+}
+```
+
+Garanta o import `response "github.com/xgodev/boost/model/restresponse"` (já
+existe) e `"github.com/xgodev/boost/model/errors"` (já existe).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./factory/contrib/labstack/echo/v4/ -run 'TestErrorStatusCode|TestErrorHandler' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add factory/contrib/labstack/echo/v4/error_handler.go factory/contrib/labstack/echo/v4/error_handler_test.go
+git commit -m "refactor(echo): map errors via registry Classify + honor ignore"
+```
+
+---
+
+## Task 6: Refactor do error mapping do gRPC + IgnoreAsSuccess
+
+**Files:**
+- Modify: `factory/contrib/google.golang.org/grpc/v1/server/error.go`
+- Test: `factory/contrib/google.golang.org/grpc/v1/server/error_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package server
+
+import (
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type customConflict struct{ msg string }
+
+func (c *customConflict) Error() string { return c.msg }
+
+func TestError_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customConflict)
+		return ok
+	}, errors.KindConflict)
+
+	got := status.Code(Error(&customConflict{"dup"}))
+	if got != codes.AlreadyExists {
+		t.Fatalf("code = %v, want AlreadyExists", got)
+	}
+}
+
+func TestError_IgnoreAsSuccess(t *testing.T) {
+	sentinel := errors.New("ignorable-grpc")
+	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
+
+	if err := Error(sentinel); err != nil {
+		t.Fatalf("Error = %v, want nil", err)
+	}
+}
+
+func TestError_BuiltinNotFound(t *testing.T) {
+	if status.Code(Error(errors.NotFoundf("x"))) != codes.NotFound {
+		t.Fatal("builtin NotFound not mapped to codes.NotFound")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./factory/contrib/google.golang.org/grpc/v1/server/ -run TestError_ -v`
+Expected: FAIL — custom error mapeia para Internal; ignore não retorna nil.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Substitua `error.go`:
+
+```go
+package server
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/xgodev/boost/model/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error converts a boost/application error to a gRPC status error.
+// Errors registered as ignore-as-success return nil.
+func Error(err error) error {
+	if err == nil {
+		return nil
+	}
+	if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+		return nil
+	}
+	if _, ok := err.(validator.ValidationErrors); ok {
+		return status.Errorf(codes.InvalidArgument, "%s", err.Error())
+	}
+	return status.Errorf(grpcCodeFor(errors.Classify(err)), "%s", err.Error())
+}
+
+// grpcCodeFor maps a boost error Kind to a gRPC code.
+func grpcCodeFor(kind errors.Kind) codes.Code {
+	switch kind {
+	case errors.KindNotFound:
+		return codes.NotFound
+	case errors.KindNotValid, errors.KindBadRequest:
+		return codes.InvalidArgument
+	case errors.KindServiceUnavailable:
+		return codes.Unavailable
+	case errors.KindConflict, errors.KindAlreadyExists:
+		return codes.AlreadyExists
+	case errors.KindNotImplemented, errors.KindNotProvisioned:
+		return codes.Unimplemented
+	case errors.KindUnauthorized:
+		return codes.Unauthenticated
+	case errors.KindForbidden:
+		return codes.PermissionDenied
+	case errors.KindTooManyRequests:
+		return codes.ResourceExhausted
+	case errors.KindTimeout:
+		return codes.DeadlineExceeded
+	default:
+		return codes.Internal
+	}
+}
+```
+
+> Nota: `KindMethodNotAllowed`, `KindNotSupported`, `KindNotAssigned` caem em
+> `codes.Internal` (preserva o comportamento atual do gRPC, que não tinha case
+> para eles).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./factory/contrib/google.golang.org/grpc/v1/server/ -run TestError_ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add factory/contrib/google.golang.org/grpc/v1/server/error.go factory/contrib/google.golang.org/grpc/v1/server/error_test.go
+git commit -m "refactor(grpc): map errors via registry Classify + honor ignore"
+```
+
+---
+
+## Task 7: Refactor do adapter function/CloudEvents + IgnoreAsSuccess
+
+**Files:**
+- Modify: `bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go`
+- Test: `bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+type customForbidden struct{ msg string }
+
+func (c *customForbidden) Error() string { return c.msg }
+
+func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customForbidden)
+		return ok
+	}, errors.KindForbidden)
+
+	if got := ErrorStatusCode(&customForbidden{"no"}); got != http.StatusForbidden {
+		t.Fatalf("ErrorStatusCode = %d, want 403", got)
+	}
+}
+
+func TestErrorStatusCode_BuiltinNotFound(t *testing.T) {
+	if ErrorStatusCode(errors.NotFoundf("x")) != http.StatusNotFound {
+		t.Fatal("builtin NotFound not mapped to 404")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/ -run TestErrorStatusCode -v`
+Expected: FAIL — custom error retorna 500.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Substitua a função `ErrorStatusCode` e ajuste `Wrapper` em `run.go`. Adicione
+o import `response "github.com/xgodev/boost/model/restresponse"`.
+
+`ErrorStatusCode`:
+
+```go
+// ErrorStatusCode translates err to the respective HTTP status code.
+func ErrorStatusCode(err error) int {
+	if _, ok := err.(validator.ValidationErrors); ok {
+		return http.StatusUnprocessableEntity
+	}
+	return response.HTTPStatusFor(errors.Classify(err))
+}
+```
+
+No `Wrapper`, trate ignore-as-success antes de montar o erro (bloco `if err != nil`):
+
+```go
+		e, err := fn(ctx, event)
+		if err != nil {
+			if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+				return ce.NewHTTPResult(http.StatusOK, "")
+			}
+			status := ErrorStatusCode(err)
+			return ce.NewHTTPResult(status, err.Error())
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/ -run TestErrorStatusCode -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run_test.go
+git commit -m "refactor(function/ce): map errors via registry Classify + honor ignore"
+```
+
+---
+
+## Task 8: IgnoreSilenceLog nos middlewares de log (echo + gRPC)
+
+**Files:**
+- Modify: `factory/contrib/labstack/echo/v4/plugins/local/wrapper/log/log.go`
+- Modify: `factory/contrib/google.golang.org/grpc/v1/server/plugins/local/wrapper/log/log.go`
+
+> Sem teste de unidade dedicado (middlewares dependem de servidor real). A
+> verificação é via `go build` + revisão. O efeito: erro com `IgnoreSilenceLog`
+> não polui log de erro.
+
+- [ ] **Step 1: Echo — baixar nível quando SilenceLog**
+
+Em `loggerMiddleware`, a `err` da request está em escopo (linha ~119). No
+`defer`, antes do `switch level`, force `Debugf` quando o erro for silenciado.
+Adicione o import `"github.com/xgodev/boost/model/errors"` e capture `err` numa
+variável visível ao defer (renomeie a declaração para antes do defer):
+
+```go
+			var err error
+			defer func() {
+				stop := time.Now()
+
+				reqSize := req.Header.Get(e.HeaderContentLength)
+				if reqSize == "" {
+					reqSize = "0"
+				}
+
+				var method func(format string, args ...interface{})
+
+				if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreSilenceLog != 0 {
+					method = logger.Debugf
+				} else {
+					switch level {
+					case "TRACE":
+						method = logger.Tracef
+					case "INFO":
+						method = logger.Infof
+					default:
+						method = logger.Debugf
+					}
+				}
+
+				method("%s %s %-7s %s %3d %s %s %13v %s %s",
+					c.RealIP(), req.Host, req.Method, req.RequestURI,
+					res.Status, reqSize, strconv.FormatInt(res.Size, 10),
+					stop.Sub(start).String(), req.Referer(), req.UserAgent(),
+				)
+			}()
+
+			if err = next(c); err != nil {
+				c.Error(err)
+			}
+
+			return nil
+```
+
+- [ ] **Step 2: gRPC — omitir campo error + baixar nível quando SilenceLog**
+
+Nos dois interceptors (`streamInterceptor` e `unaryInterceptor`), troque o bloco
+`if err != nil { logger = logger.WithField("error", err.Error()) }` e a escolha
+do método. Adicione o import `"github.com/xgodev/boost/model/errors"`.
+
+`unaryInterceptor` (mesma ideia no `streamInterceptor`):
+
+```go
+		silenced := false
+		if err != nil {
+			if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreSilenceLog != 0 {
+				silenced = true
+			} else {
+				logger = logger.WithField("error", err.Error())
+			}
+		}
+
+		method := i.m(logger)
+		if silenced {
+			method = logger.Debugf
+		}
+		method("unary request received")
+		return resp, err
+```
+
+(No `streamInterceptor`, a mensagem é `"stream request received"`.)
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./...`
+Expected: sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add factory/contrib/labstack/echo/v4/plugins/local/wrapper/log/log.go factory/contrib/google.golang.org/grpc/v1/server/plugins/local/wrapper/log/log.go
+git commit -m "feat(log): honor IgnoreSilenceLog in echo and grpc log middlewares"
+```
+
+---
+
+## Task 9: Verificação global (build + vet + test)
+
+**Files:** nenhum (gate).
+
+- [ ] **Step 1: Build, vet, test**
+
+Run:
+```bash
+gofmt -l model/errors model/restresponse factory bootstrap
+go vet ./...
+go build ./...
+go test ./...
+```
+Expected: `gofmt -l` vazio; vet sem warning; build ok; testes verdes.
+
+- [ ] **Step 2: Commit (se houve format)**
+
+```bash
+git add -A && git commit -m "chore: gofmt" || echo "nada a formatar"
+```
+
+---
+
+## Task 10: Docs + skills + bump do plugin (Iron Law #6)
+
+**Files:**
+- Modify: `skills/boost-model-errors/SKILL.md` — seção "Registrar erros customizados": `Register`/`RegisterMatch`/`Classify`/`Ignore` + tabela `Kind → HTTP/gRPC`.
+- Modify: `skills/boost-factory-echo/SKILL.md` — nota de que o error_handler resolve via registry.
+- Modify: `skills/boost-factory-grpc/SKILL.md` — idem para o `Error`.
+- Modify: READMEs de `model/errors`, `model/restresponse` (se existirem) — nova API.
+- Modify: `.claude-plugin/plugin.json` — bump de versão.
+
+> Antes de editar QUALQUER `SKILL.md`, invoque `superpowers:writing-skills`
+> (baseline com subagent primeiro). Antes de criar hook, `hookify:writing-rules`.
+
+- [ ] **Step 1: Atualizar skill boost-model-errors**
+
+Documente o exemplo canônico:
+
+```go
+// No boot, antes de servir:
+errors.Register(MyXptoError, errors.KindNotFound)        // 404 / NotFound
+errors.RegisterMatch(func(e error) bool {                 // por tipo
+    var x *MyTypedErr; return errors.As(e, &x)
+}, errors.KindConflict)
+errors.Ignore(MyNoiseError)                               // 200/OK + sem log
+errors.Ignore(MyAuditErr, errors.IgnoreSilenceLog)        // status normal, sem log
+```
+
+E a tabela `Kind → HTTP / gRPC` (de `HTTPStatusFor` e `grpcCodeFor`).
+
+- [ ] **Step 2: Atualizar skills echo + grpc + READMEs**
+
+Nota curta: "erros são classificados via `errors.Classify`; registre erros
+customizados com `errors.Register`/`RegisterMatch`."
+
+- [ ] **Step 3: Bump do plugin**
+
+Edite `.claude-plugin/plugin.json` subindo a versão (ex.: patch→minor conforme
+a convenção do repo).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills .claude-plugin/plugin.json model/errors/README.md model/restresponse/README.md 2>/dev/null
+git commit -m "docs(errors): document custom error registry in skills and READMEs"
+```
+
+---
+
+## Notas de design recapituladas
+
+- `model/errors` permanece agnóstico de transporte: `Kind` é só um inteiro; as
+  tabelas `Kind→código` ficam em `restresponse` (HTTP) e no pacote `server` (gRPC).
+- Precedência de `Classify`: registrados → `Is*` embutido → `KindInternal`.
+- `validator.ValidationErrors` segue tratado em cada transporte (não entra no
+  registry), preservando HTTP 422 / gRPC InvalidArgument.
+- Ignore é por bits (`IgnoreAsSuccess | IgnoreSilenceLog`); sem opção = ambos.
+- `IgnoreSilenceLog` atua nos middlewares de log (echo/gRPC); no adapter CE não
+  há log por-evento do erro, então só o `IgnoreAsSuccess` se aplica lá.
+- Registro deve ocorrer no boot, antes de servir (registry sob `RWMutex`).
+```

--- a/docs/superpowers/specs/2026-06-01-error-registry-design.md
+++ b/docs/superpowers/specs/2026-06-01-error-registry-design.md
@@ -1,0 +1,147 @@
+# Registry de erros customizados → código de transporte
+
+## Problema
+
+O mapeamento "erro → código de transporte" está copiado em 3 lugares, cada um
+com o mesmo `switch` sobre `errors.Is*`:
+
+- HTTP/Echo — `factory/contrib/labstack/echo/v4/error_handler.go` (`ErrorStatusCode`)
+- gRPC — `factory/contrib/google.golang.org/grpc/v1/server/error.go` (`Error`)
+- function/CloudEvents — `bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go` (`ErrorStatusCode`)
+
+Hoje só dá pra mapear os erros do próprio boost. Não há como dizer que um erro
+da aplicação (ex. `XptoError`) deve retornar 404, nem ignorar certos erros. Pra
+isso seria preciso editar os 3 switches na mão.
+
+## Objetivo
+
+Um registry único onde a aplicação registra erros customizados e diz qual
+**semântico boost** eles têm (que resolve HTTP e gRPC de uma vez), ou marca pra
+ignorar. Vale nos 3 transportes.
+
+```go
+errors.Register(MyXptoError, errors.KindNotFound) // → 404 HTTP / NotFound gRPC
+errors.Ignore(MyNoiseError, errors.IgnoreSilenceLog) // não loga, status normal
+```
+
+## Não-objetivos
+
+- Não declarar código HTTP/gRPC cru por erro (sempre via `Kind` semântico).
+- Não mudar a semântica dos `Is*` existentes (retrocompat).
+- Não tocar `http2`/`graphql-go` (não mapeiam erro hoje).
+
+## Decisões travadas
+
+- Registro por **semântico boost** (`Kind`), não por código cru.
+- Escopo: os **3 transportes**.
+- Ignore é **configurável por erro**: virar sucesso, só silenciar log, ou ambos.
+
+## Desenho
+
+### 1. `model/errors` — registry + classificação (sem dependência de transporte)
+
+`Kind` é um enum que espelha o catálogo atual de `Is*`. O pacote **não** importa
+`net/http` nem `grpc/codes` — `Kind` é só um inteiro semântico.
+
+```go
+type Kind int
+
+const (
+    KindInternal Kind = iota // default / fallback
+    KindNotFound
+    KindBadRequest
+    KindNotValid
+    KindConflict
+    KindAlreadyExists
+    KindForbidden
+    KindUnauthorized
+    KindServiceUnavailable
+    KindNotImplemented
+    KindNotProvisioned
+    KindNotSupported
+    KindNotAssigned
+    KindMethodNotAllowed
+    KindTooManyRequests
+    KindTimeout
+)
+```
+
+Registro (chamado no boot, antes de servir):
+
+```go
+// casa via errors.Is(err, target) — bom pra sentinelas
+func Register(target error, kind Kind)
+// casa por predicado/tipo (errors.As) — bom pra XptoError concreto
+func RegisterMatch(match func(error) bool, kind Kind)
+
+// ignore configurável
+type IgnoreOption int
+const (
+    IgnoreAsSuccess IgnoreOption = 1 << iota // resposta vira sucesso (200/OK)
+    IgnoreSilenceLog                          // não loga (ou nível baixo)
+)
+func Ignore(target error, opts ...IgnoreOption)            // sem opts = ambos
+func IgnoreMatch(match func(error) bool, opts ...IgnoreOption)
+```
+
+Resolução:
+
+```go
+// precedência: matchers registrados (ordem de registro, 1º vence) → Is* embutido → KindInternal
+func Classify(err error) Kind
+// política de ignore, se houver
+func IgnoreOf(err error) (IgnoreOption, bool)
+```
+
+Concorrência: registry protegido por `sync.RWMutex`. Registro no `init`/setup do
+boot; leituras (`Classify`/`IgnoreOf`) em request time.
+
+### 2. Tabelas `Kind → código` (na borda de cada transporte)
+
+- HTTP: `restresponse.HTTPStatusFor(kind errors.Kind) int` — casa nova
+  compartilhada por **echo** e **function/CE** (ambos já importam `restresponse`;
+  `restresponse` passa a importar `model/errors`, sem ciclo). Mata a duplicação
+  da tabela HTTP.
+- gRPC: tabela `Kind → codes.Code` no pacote `grpc/v1/server`.
+
+### 3. Refactor dos 3 handlers
+
+Cada handler passa a:
+
+1. `kind := errors.Classify(err)` → lookup do código por `Kind`.
+2. Antes de montar a resposta: `if pol, ok := errors.IgnoreOf(err); ok` →
+   - `IgnoreAsSuccess`: HTTP 200/204, gRPC `codes.OK`/`nil`.
+   - `IgnoreSilenceLog`: pula/abaixa o log.
+
+Os `*HTTPError` do echo e `validator.ValidationErrors` continuam tratados como
+hoje.
+
+### 4. Skills + docs (Iron Law #6)
+
+No mesmo PR: atualizar `skills/boost-model-errors`, `boost-factory-echo`,
+`boost-factory-grpc` + READMEs dos pacotes. Bump da versão do plugin em
+`.claude-plugin/plugin.json`.
+
+## Testes (TDD — vermelho primeiro)
+
+- `Register(XptoError, KindNotFound)` → 404 (echo), `codes.NotFound` (gRPC),
+  404 (CE).
+- `RegisterMatch` por tipo concreto.
+- `Ignore` → sucesso; `IgnoreSilenceLog` → status normal sem log; ambos.
+- Precedência: erro registrado ganha do `Is*` embutido.
+- Compat: todos os `Is*` e mapeamentos default inalterados.
+- Concorrência: `Classify` sob leitura concorrente.
+
+## Arquivos
+
+Novos:
+- `model/errors/registry.go`, `model/errors/registry_test.go`
+- `model/errors/kind.go` (enum)
+
+Alterados:
+- `model/restresponse/` — `HTTPStatusFor`
+- `factory/contrib/labstack/echo/v4/error_handler.go`
+- `factory/contrib/google.golang.org/grpc/v1/server/error.go`
+- `bootstrap/function/adapter/contrib/cloudevents/sdk-go/v2/core/http/run.go`
+- `skills/boost-model-errors`, `skills/boost-factory-echo`, `skills/boost-factory-grpc`
+- `.claude-plugin/plugin.json` (bump)

--- a/factory/contrib/google.golang.org/grpc/v1/server/error.go
+++ b/factory/contrib/google.golang.org/grpc/v1/server/error.go
@@ -7,29 +7,43 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Error converts errors to grpc errors
+// Error converts a boost/application error to a gRPC status error.
+// Errors registered as ignore-as-success return nil.
 func Error(err error) error {
-
-	if errors.IsNotFound(err) {
-		return status.Errorf(codes.NotFound, "%s", err.Error())
-	} else if errors.IsNotValid(err) || errors.IsBadRequest(err) {
+	if err == nil {
+		return nil
+	}
+	if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+		return nil
+	}
+	if _, ok := err.(validator.ValidationErrors); ok {
 		return status.Errorf(codes.InvalidArgument, "%s", err.Error())
-	} else if errors.IsServiceUnavailable(err) {
-		return status.Errorf(codes.Unavailable, "%s", err.Error())
-	} else if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
-		return status.Errorf(codes.AlreadyExists, "%s", err.Error())
-	} else if errors.IsNotImplemented(err) || errors.IsNotProvisioned(err) {
-		return status.Errorf(codes.Unimplemented, "%s", err.Error())
-	} else if errors.IsUnauthorized(err) {
-		return status.Errorf(codes.Unauthenticated, "%s", err.Error())
-	} else if errors.IsForbidden(err) {
-		return status.Errorf(codes.PermissionDenied, "%s", err.Error())
-	} else {
-		switch t := err.(type) {
-		case validator.ValidationErrors:
-			return status.Errorf(codes.InvalidArgument, "%s", t.Error())
-		default:
-			return status.Errorf(codes.Internal, "%s", t.Error())
-		}
+	}
+	return status.Errorf(grpcCodeFor(errors.Classify(err)), "%s", err.Error())
+}
+
+// grpcCodeFor maps a boost error Kind to a gRPC code.
+func grpcCodeFor(kind errors.Kind) codes.Code {
+	switch kind {
+	case errors.KindNotFound:
+		return codes.NotFound
+	case errors.KindNotValid, errors.KindBadRequest:
+		return codes.InvalidArgument
+	case errors.KindServiceUnavailable:
+		return codes.Unavailable
+	case errors.KindConflict, errors.KindAlreadyExists:
+		return codes.AlreadyExists
+	case errors.KindNotImplemented, errors.KindNotProvisioned:
+		return codes.Unimplemented
+	case errors.KindUnauthorized:
+		return codes.Unauthenticated
+	case errors.KindForbidden:
+		return codes.PermissionDenied
+	case errors.KindTooManyRequests:
+		return codes.ResourceExhausted
+	case errors.KindTimeout:
+		return codes.DeadlineExceeded
+	default:
+		return codes.Internal
 	}
 }

--- a/factory/contrib/google.golang.org/grpc/v1/server/error_test.go
+++ b/factory/contrib/google.golang.org/grpc/v1/server/error_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type customConflict struct{ msg string }
+
+func (c *customConflict) Error() string { return c.msg }
+
+func TestError_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customConflict)
+		return ok
+	}, errors.KindConflict)
+
+	if got := status.Code(Error(&customConflict{"dup"})); got != codes.AlreadyExists {
+		t.Fatalf("code = %v, want AlreadyExists", got)
+	}
+}
+
+func TestError_IgnoreAsSuccess(t *testing.T) {
+	sentinel := errors.New("ignorable-grpc")
+	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
+
+	if err := Error(sentinel); err != nil {
+		t.Fatalf("Error = %v, want nil", err)
+	}
+}
+
+func TestError_BuiltinNotFound(t *testing.T) {
+	if status.Code(Error(errors.NotFoundf("x"))) != codes.NotFound {
+		t.Fatal("builtin NotFound not mapped to codes.NotFound")
+	}
+}
+
+func TestError_DefaultInternal(t *testing.T) {
+	if status.Code(Error(errors.New("plain"))) != codes.Internal {
+		t.Fatal("plain error not mapped to codes.Internal")
+	}
+}

--- a/factory/contrib/google.golang.org/grpc/v1/server/error_test.go
+++ b/factory/contrib/google.golang.org/grpc/v1/server/error_test.go
@@ -13,6 +13,7 @@ type customConflict struct{ msg string }
 func (c *customConflict) Error() string { return c.msg }
 
 func TestError_RegisteredCustom(t *testing.T) {
+	defer errors.ResetRegistry()
 	errors.RegisterMatch(func(err error) bool {
 		_, ok := err.(*customConflict)
 		return ok
@@ -24,6 +25,7 @@ func TestError_RegisteredCustom(t *testing.T) {
 }
 
 func TestError_IgnoreAsSuccess(t *testing.T) {
+	defer errors.ResetRegistry()
 	sentinel := errors.New("ignorable-grpc")
 	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
 

--- a/factory/contrib/google.golang.org/grpc/v1/server/plugins/local/wrapper/log/log.go
+++ b/factory/contrib/google.golang.org/grpc/v1/server/plugins/local/wrapper/log/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/xgodev/boost/model/errors"
 	"github.com/xgodev/boost/wrapper/log"
 	"google.golang.org/grpc"
 )
@@ -93,12 +94,20 @@ func (i *Log) streamInterceptor() grpc.StreamServerInterceptor {
 			"duration": time.Since(start),
 		})
 
+		silenced := false
 		if err != nil {
-			logger = logger.WithField("error", err.Error())
+			if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreSilenceLog != 0 {
+				silenced = true
+			} else {
+				logger = logger.WithField("error", err.Error())
+			}
 		}
 
-		xx := i.m(logger)
-		xx("stream request received")
+		method := i.m(logger)
+		if silenced {
+			method = logger.Debugf
+		}
+		method("stream request received")
 		return err
 	}
 }
@@ -118,12 +127,20 @@ func (i *Log) unaryInterceptor() grpc.UnaryServerInterceptor {
 			"req":      req,
 		})
 
+		silenced := false
 		if err != nil {
-			logger = logger.WithField("error", err.Error())
+			if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreSilenceLog != 0 {
+				silenced = true
+			} else {
+				logger = logger.WithField("error", err.Error())
+			}
 		}
 
-		xx := i.m(logger)
-		xx("unary request received")
+		method := i.m(logger)
+		if silenced {
+			method = logger.Debugf
+		}
+		method("unary request received")
 		return resp, err
 	}
 }

--- a/factory/contrib/labstack/echo/v4/error_handler.go
+++ b/factory/contrib/labstack/echo/v4/error_handler.go
@@ -22,6 +22,13 @@ func ErrorHandlerJSON(err error, c e.Context) {
 }
 
 func errorHandler(err error, c e.Context, contentType string) {
+	if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreAsSuccess != 0 {
+		if er := c.NoContent(http.StatusOK); er != nil {
+			c.Logger().Error(er)
+		}
+		return
+	}
+
 	var (
 		status  int
 		message string
@@ -50,32 +57,10 @@ func errorHandler(err error, c e.Context, contentType string) {
 	}
 }
 
-// ErrorStatusCode translates to the respective status code.
+// ErrorStatusCode translates err to the respective HTTP status code.
 func ErrorStatusCode(err error) int {
-
-	switch {
-	case errors.IsNotFound(err):
-		return http.StatusNotFound
-	case errors.IsMethodNotAllowed(err):
-		return http.StatusMethodNotAllowed
-	case errors.IsNotValid(err) || errors.IsBadRequest(err):
-		return http.StatusBadRequest
-	case errors.IsServiceUnavailable(err):
-		return http.StatusServiceUnavailable
-	case errors.IsConflict(err) || errors.IsAlreadyExists(err):
-		return http.StatusConflict
-	case errors.IsNotImplemented(err) || errors.IsNotProvisioned(err):
-		return http.StatusNotImplemented
-	case errors.IsUnauthorized(err):
-		return http.StatusUnauthorized
-	case errors.IsForbidden(err):
-		return http.StatusForbidden
-	case errors.IsNotSupported(err) || errors.IsNotAssigned(err):
+	if _, ok := err.(validator.ValidationErrors); ok {
 		return http.StatusUnprocessableEntity
-	default:
-		if _, ok := err.(validator.ValidationErrors); ok {
-			return http.StatusUnprocessableEntity
-		}
-		return http.StatusInternalServerError
 	}
+	return response.HTTPStatusFor(errors.Classify(err))
 }

--- a/factory/contrib/labstack/echo/v4/error_handler_test.go
+++ b/factory/contrib/labstack/echo/v4/error_handler_test.go
@@ -1,0 +1,46 @@
+package echo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	e "github.com/labstack/echo/v4"
+	"github.com/xgodev/boost/model/errors"
+)
+
+type customNotFound struct{ msg string }
+
+func (c *customNotFound) Error() string { return c.msg }
+
+func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	errors.RegisterMatch(func(err error) bool {
+		_, ok := err.(*customNotFound)
+		return ok
+	}, errors.KindNotFound)
+
+	if got := ErrorStatusCode(&customNotFound{"missing"}); got != http.StatusNotFound {
+		t.Fatalf("ErrorStatusCode = %d, want 404", got)
+	}
+}
+
+func TestErrorStatusCode_BuiltinNotFound(t *testing.T) {
+	if got := ErrorStatusCode(errors.NotFoundf("x")); got != http.StatusNotFound {
+		t.Fatalf("ErrorStatusCode = %d, want 404", got)
+	}
+}
+
+func TestErrorHandler_IgnoreAsSuccess(t *testing.T) {
+	sentinel := errors.New("ignorable")
+	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
+
+	rec := httptest.NewRecorder()
+	srv := e.New()
+	c := srv.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+
+	errorHandler(sentinel, c, e.MIMEApplicationJSON)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}

--- a/factory/contrib/labstack/echo/v4/error_handler_test.go
+++ b/factory/contrib/labstack/echo/v4/error_handler_test.go
@@ -14,6 +14,7 @@ type customNotFound struct{ msg string }
 func (c *customNotFound) Error() string { return c.msg }
 
 func TestErrorStatusCode_RegisteredCustom(t *testing.T) {
+	defer errors.ResetRegistry()
 	errors.RegisterMatch(func(err error) bool {
 		_, ok := err.(*customNotFound)
 		return ok
@@ -31,6 +32,7 @@ func TestErrorStatusCode_BuiltinNotFound(t *testing.T) {
 }
 
 func TestErrorHandler_IgnoreAsSuccess(t *testing.T) {
+	defer errors.ResetRegistry()
 	sentinel := errors.New("ignorable")
 	errors.Ignore(sentinel, errors.IgnoreAsSuccess)
 

--- a/factory/contrib/labstack/echo/v4/plugins/local/wrapper/log/log.go
+++ b/factory/contrib/labstack/echo/v4/plugins/local/wrapper/log/log.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	e "github.com/labstack/echo/v4"
+	"github.com/xgodev/boost/model/errors"
 	"github.com/xgodev/boost/wrapper/log"
 )
 
@@ -83,6 +84,7 @@ func loggerMiddleware(level string) e.MiddlewareFunc {
 			ctx = logger.ToContext(ctx)
 			c.SetRequest(req.WithContext(ctx))
 
+			var err error
 			defer func() {
 				stop := time.Now()
 
@@ -93,13 +95,17 @@ func loggerMiddleware(level string) e.MiddlewareFunc {
 
 				var method func(format string, args ...interface{})
 
-				switch level {
-				case "TRACE":
-					method = logger.Tracef
-				case "INFO":
-					method = logger.Infof
-				default:
+				if pol, ok := errors.IgnoreOf(err); ok && pol&errors.IgnoreSilenceLog != 0 {
 					method = logger.Debugf
+				} else {
+					switch level {
+					case "TRACE":
+						method = logger.Tracef
+					case "INFO":
+						method = logger.Infof
+					default:
+						method = logger.Debugf
+					}
 				}
 
 				method("%s %s %-7s %s %3d %s %s %13v %s %s",
@@ -116,7 +122,6 @@ func loggerMiddleware(level string) e.MiddlewareFunc {
 				)
 			}()
 
-			var err error
 			if err = next(c); err != nil {
 				c.Error(err)
 			}

--- a/model/errors/kind.go
+++ b/model/errors/kind.go
@@ -1,0 +1,64 @@
+package errors
+
+// Kind is a transport-agnostic semantic classification of an error.
+type Kind int
+
+const (
+	KindInternal Kind = iota // default / fallback
+	KindNotFound
+	KindBadRequest
+	KindNotValid
+	KindConflict
+	KindAlreadyExists
+	KindForbidden
+	KindUnauthorized
+	KindServiceUnavailable
+	KindNotImplemented
+	KindNotProvisioned
+	KindNotSupported
+	KindNotAssigned
+	KindMethodNotAllowed
+	KindTooManyRequests
+	KindTimeout
+)
+
+// builtinKind classifies err using the typed error catalog (Is* checks).
+// More specific types are checked first; IsNotValid is checked before
+// IsBadRequest because the two may overlap. Unmatched errors fall back to
+// KindInternal.
+func builtinKind(err error) Kind {
+	switch {
+	case IsNotFound(err):
+		return KindNotFound
+	case IsMethodNotAllowed(err):
+		return KindMethodNotAllowed
+	case IsNotValid(err):
+		return KindNotValid
+	case IsBadRequest(err):
+		return KindBadRequest
+	case IsServiceUnavailable(err):
+		return KindServiceUnavailable
+	case IsConflict(err):
+		return KindConflict
+	case IsAlreadyExists(err):
+		return KindAlreadyExists
+	case IsNotImplemented(err):
+		return KindNotImplemented
+	case IsNotProvisioned(err):
+		return KindNotProvisioned
+	case IsUnauthorized(err):
+		return KindUnauthorized
+	case IsForbidden(err):
+		return KindForbidden
+	case IsNotSupported(err):
+		return KindNotSupported
+	case IsNotAssigned(err):
+		return KindNotAssigned
+	case IsTooManyRequests(err):
+		return KindTooManyRequests
+	case IsTimeout(err):
+		return KindTimeout
+	default:
+		return KindInternal
+	}
+}

--- a/model/errors/kind_test.go
+++ b/model/errors/kind_test.go
@@ -1,0 +1,37 @@
+package errors
+
+import "testing"
+
+func TestBuiltinKind(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want Kind
+	}{
+		{"NotFound", NotFoundf("x"), KindNotFound},
+		{"BadRequest", BadRequestf("x"), KindBadRequest},
+		{"NotValid", NotValidf("x"), KindNotValid},
+		{"Conflict", Conflictf("x"), KindConflict},
+		{"AlreadyExists", AlreadyExistsf("x"), KindAlreadyExists},
+		{"Forbidden", Forbiddenf("x"), KindForbidden},
+		{"Unauthorized", Unauthorizedf("x"), KindUnauthorized},
+		{"ServiceUnavailable", ServiceUnavailablef("x"), KindServiceUnavailable},
+		{"NotImplemented", NotImplementedf("x"), KindNotImplemented},
+		{"NotProvisioned", NotProvisionedf("x"), KindNotProvisioned},
+		{"NotSupported", NotSupportedf("x"), KindNotSupported},
+		{"NotAssigned", NotAssignedf("x"), KindNotAssigned},
+		{"MethodNotAllowed", MethodNotAllowedf("x"), KindMethodNotAllowed},
+		{"TooManyRequests", TooManyRequestsf("x"), KindTooManyRequests},
+		{"Timeout", Timeoutf("x"), KindTimeout},
+		{"Internal", Internalf("x"), KindInternal},
+		{"PlainNew", New("x"), KindInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := builtinKind(tt.err); got != tt.want {
+				t.Fatalf("builtinKind(%s) = %d, want %d", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/model/errors/registry.go
+++ b/model/errors/registry.go
@@ -1,0 +1,146 @@
+package errors
+
+import "sync"
+
+// matcher associates a predicate with the Kind to return when it matches.
+type matcher struct {
+	match func(error) bool
+	kind  Kind
+}
+
+// ignoreRule associates a predicate with the ignore policy to apply.
+type ignoreRule struct {
+	match  func(error) bool
+	policy IgnoreOption
+}
+
+// IgnoreOption is a bit flag describing how a matched error should be ignored.
+type IgnoreOption int
+
+const (
+	// IgnoreAsSuccess treats the matched error as a successful outcome.
+	IgnoreAsSuccess IgnoreOption = 1 << iota
+	// IgnoreSilenceLog suppresses logging for the matched error.
+	IgnoreSilenceLog
+)
+
+var (
+	mu       sync.RWMutex
+	matchers []matcher
+	ignores  []ignoreRule
+)
+
+// Register registers target so that any error matching it (via Is) is
+// classified as kind. For custom predicates see RegisterMatch and its note on
+// not calling back into the registry from within a matcher.
+func Register(target error, kind Kind) {
+	mu.Lock()
+	defer mu.Unlock()
+	matchers = append(matchers, matcher{
+		match: func(err error) bool { return Is(err, target) },
+		kind:  kind,
+	})
+}
+
+// RegisterMatch registers a custom predicate to classify errors as kind. A nil
+// match is a no-op. The match function must not call back into this package's
+// registry (Register/RegisterMatch/Classify/Ignore/IgnoreMatch/IgnoreOf), as
+// matchers run while the registry lock is held.
+func RegisterMatch(match func(error) bool, kind Kind) {
+	if match == nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	matchers = append(matchers, matcher{match: match, kind: kind})
+}
+
+// Classify returns the Kind of err. Registered matchers are evaluated in order
+// (first match wins); if none match it falls back to builtinKind. A nil err is
+// classified as KindInternal.
+func Classify(err error) Kind {
+	if err == nil {
+		return KindInternal
+	}
+
+	mu.RLock()
+	for _, m := range matchers {
+		if m.match(err) {
+			kind := m.kind
+			mu.RUnlock()
+			return kind
+		}
+	}
+	mu.RUnlock()
+
+	return builtinKind(err)
+}
+
+// Ignore registers target so that any error matching it (via Is) is ignored
+// according to opts. With no opts the full ignore policy
+// (IgnoreAsSuccess | IgnoreSilenceLog) is applied. For custom predicates see
+// IgnoreMatch and its note on not calling back into the registry from within a
+// matcher.
+func Ignore(target error, opts ...IgnoreOption) {
+	policy := combineOptions(opts)
+	mu.Lock()
+	defer mu.Unlock()
+	ignores = append(ignores, ignoreRule{
+		match:  func(err error) bool { return Is(err, target) },
+		policy: policy,
+	})
+}
+
+// IgnoreMatch registers a custom predicate to ignore errors according to opts.
+// A nil match is a no-op. With no opts the full ignore policy
+// (IgnoreAsSuccess | IgnoreSilenceLog) is applied. The match function must not
+// call back into this package's registry
+// (Register/RegisterMatch/Classify/Ignore/IgnoreMatch/IgnoreOf), as matchers
+// run while the registry lock is held.
+func IgnoreMatch(match func(error) bool, opts ...IgnoreOption) {
+	if match == nil {
+		return
+	}
+	policy := combineOptions(opts)
+	mu.Lock()
+	defer mu.Unlock()
+	ignores = append(ignores, ignoreRule{match: match, policy: policy})
+}
+
+// IgnoreOf returns the ignore policy registered for err and whether one was
+// found. Registered rules are evaluated in order (first match wins). A nil err
+// returns (0, false).
+func IgnoreOf(err error) (IgnoreOption, bool) {
+	if err == nil {
+		return 0, false
+	}
+	mu.RLock()
+	defer mu.RUnlock()
+	for _, r := range ignores {
+		if r.match(err) {
+			return r.policy, true
+		}
+	}
+	return 0, false
+}
+
+// combineOptions ORs the provided opts, defaulting to the full ignore policy
+// when none are supplied.
+func combineOptions(opts []IgnoreOption) IgnoreOption {
+	if len(opts) == 0 {
+		return IgnoreAsSuccess | IgnoreSilenceLog
+	}
+	var policy IgnoreOption
+	for _, o := range opts {
+		policy |= o
+	}
+	return policy
+}
+
+// resetRegistry clears all registered matchers and ignore rules. Test-only.
+func resetRegistry() {
+	mu.Lock()
+	defer mu.Unlock()
+	matchers = nil
+	ignores = nil
+}

--- a/model/errors/registry.go
+++ b/model/errors/registry.go
@@ -137,8 +137,10 @@ func combineOptions(opts []IgnoreOption) IgnoreOption {
 	return policy
 }
 
-// resetRegistry clears all registered matchers and ignore rules. Test-only.
-func resetRegistry() {
+// ResetRegistry clears all registered matchers and ignore rules. It is intended
+// for test teardown so a test that calls Register/RegisterMatch/Ignore/IgnoreMatch
+// can `defer errors.ResetRegistry()` to avoid leaking global state into other tests.
+func ResetRegistry() {
 	mu.Lock()
 	defer mu.Unlock()
 	matchers = nil

--- a/model/errors/registry_test.go
+++ b/model/errors/registry_test.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	stderrors "errors"
+	"testing"
+)
+
+func TestClassifyRegisteredSentinel(t *testing.T) {
+	defer resetRegistry()
+
+	sentinel := New("sentinel not found")
+	Register(sentinel, KindNotFound)
+
+	if got := Classify(sentinel); got != KindNotFound {
+		t.Fatalf("Classify(sentinel) = %d, want %d", got, KindNotFound)
+	}
+}
+
+type xptoError struct{ msg string }
+
+func (e *xptoError) Error() string { return e.msg }
+
+func TestClassifyRegisteredMatch(t *testing.T) {
+	defer resetRegistry()
+
+	RegisterMatch(func(err error) bool {
+		var target *xptoError
+		return stderrors.As(err, &target)
+	}, KindNotFound)
+
+	if got := Classify(&xptoError{msg: "boom"}); got != KindNotFound {
+		t.Fatalf("Classify(xptoError) = %d, want %d", got, KindNotFound)
+	}
+}
+
+func TestClassifyFallsBackToBuiltin(t *testing.T) {
+	defer resetRegistry()
+
+	if got := Classify(NotFoundf("x")); got != KindNotFound {
+		t.Fatalf("Classify(NotFoundf) = %d, want %d", got, KindNotFound)
+	}
+}
+
+func TestClassifyDefaultInternal(t *testing.T) {
+	defer resetRegistry()
+
+	if got := Classify(New("anything")); got != KindInternal {
+		t.Fatalf("Classify(New) = %d, want %d", got, KindInternal)
+	}
+}
+
+func TestClassifyRegisteredWinsOverBuiltin(t *testing.T) {
+	defer resetRegistry()
+
+	err := NotFoundf("x")
+	Register(err, KindConflict)
+
+	if got := Classify(err); got != KindConflict {
+		t.Fatalf("Classify(registered) = %d, want %d", got, KindConflict)
+	}
+}
+
+func TestIgnoreDefaultBoth(t *testing.T) {
+	defer resetRegistry()
+
+	e := New("ignored")
+	Ignore(e)
+
+	opt, ok := IgnoreOf(e)
+	if !ok {
+		t.Fatalf("IgnoreOf(e) ok = false, want true")
+	}
+	if opt&IgnoreAsSuccess == 0 || opt&IgnoreSilenceLog == 0 {
+		t.Fatalf("IgnoreOf(e) = %d, want both bits set", opt)
+	}
+}
+
+func TestIgnoreSilenceOnly(t *testing.T) {
+	defer resetRegistry()
+
+	e := New("ignored")
+	Ignore(e, IgnoreSilenceLog)
+
+	opt, ok := IgnoreOf(e)
+	if !ok {
+		t.Fatalf("IgnoreOf(e) ok = false, want true")
+	}
+	if opt&IgnoreSilenceLog == 0 {
+		t.Fatalf("IgnoreOf(e) missing IgnoreSilenceLog, got %d", opt)
+	}
+	if opt&IgnoreAsSuccess != 0 {
+		t.Fatalf("IgnoreOf(e) unexpectedly has IgnoreAsSuccess, got %d", opt)
+	}
+}
+
+func TestIgnoreOfUnregistered(t *testing.T) {
+	defer resetRegistry()
+
+	if _, ok := IgnoreOf(New("x")); ok {
+		t.Fatalf("IgnoreOf(unregistered) ok = true, want false")
+	}
+}

--- a/model/errors/registry_test.go
+++ b/model/errors/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestClassifyRegisteredSentinel(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	sentinel := New("sentinel not found")
 	Register(sentinel, KindNotFound)
@@ -21,7 +21,7 @@ type xptoError struct{ msg string }
 func (e *xptoError) Error() string { return e.msg }
 
 func TestClassifyRegisteredMatch(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	RegisterMatch(func(err error) bool {
 		var target *xptoError
@@ -34,7 +34,7 @@ func TestClassifyRegisteredMatch(t *testing.T) {
 }
 
 func TestClassifyFallsBackToBuiltin(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	if got := Classify(NotFoundf("x")); got != KindNotFound {
 		t.Fatalf("Classify(NotFoundf) = %d, want %d", got, KindNotFound)
@@ -42,7 +42,7 @@ func TestClassifyFallsBackToBuiltin(t *testing.T) {
 }
 
 func TestClassifyDefaultInternal(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	if got := Classify(New("anything")); got != KindInternal {
 		t.Fatalf("Classify(New) = %d, want %d", got, KindInternal)
@@ -50,7 +50,7 @@ func TestClassifyDefaultInternal(t *testing.T) {
 }
 
 func TestClassifyRegisteredWinsOverBuiltin(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	err := NotFoundf("x")
 	Register(err, KindConflict)
@@ -61,7 +61,7 @@ func TestClassifyRegisteredWinsOverBuiltin(t *testing.T) {
 }
 
 func TestIgnoreDefaultBoth(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	e := New("ignored")
 	Ignore(e)
@@ -76,7 +76,7 @@ func TestIgnoreDefaultBoth(t *testing.T) {
 }
 
 func TestIgnoreSilenceOnly(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	e := New("ignored")
 	Ignore(e, IgnoreSilenceLog)
@@ -94,7 +94,7 @@ func TestIgnoreSilenceOnly(t *testing.T) {
 }
 
 func TestIgnoreOfUnregistered(t *testing.T) {
-	defer resetRegistry()
+	defer ResetRegistry()
 
 	if _, ok := IgnoreOf(New("x")); ok {
 		t.Fatalf("IgnoreOf(unregistered) ok = true, want false")

--- a/model/restresponse/status_code.go
+++ b/model/restresponse/status_code.go
@@ -1,0 +1,37 @@
+package response
+
+import (
+	"net/http"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+// HTTPStatusFor maps a boost error Kind to its HTTP status code.
+func HTTPStatusFor(kind errors.Kind) int {
+	switch kind {
+	case errors.KindNotFound:
+		return http.StatusNotFound
+	case errors.KindMethodNotAllowed:
+		return http.StatusMethodNotAllowed
+	case errors.KindNotValid, errors.KindBadRequest:
+		return http.StatusBadRequest
+	case errors.KindServiceUnavailable:
+		return http.StatusServiceUnavailable
+	case errors.KindConflict, errors.KindAlreadyExists:
+		return http.StatusConflict
+	case errors.KindNotImplemented, errors.KindNotProvisioned:
+		return http.StatusNotImplemented
+	case errors.KindUnauthorized:
+		return http.StatusUnauthorized
+	case errors.KindForbidden:
+		return http.StatusForbidden
+	case errors.KindNotSupported, errors.KindNotAssigned:
+		return http.StatusUnprocessableEntity
+	case errors.KindTooManyRequests:
+		return http.StatusTooManyRequests
+	case errors.KindTimeout:
+		return http.StatusRequestTimeout
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/model/restresponse/status_code_test.go
+++ b/model/restresponse/status_code_test.go
@@ -1,0 +1,41 @@
+package response
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/xgodev/boost/model/errors"
+)
+
+func TestHTTPStatusFor(t *testing.T) {
+	tests := []struct {
+		name string
+		kind errors.Kind
+		want int
+	}{
+		{"NotFound", errors.KindNotFound, http.StatusNotFound},
+		{"MethodNotAllowed", errors.KindMethodNotAllowed, http.StatusMethodNotAllowed},
+		{"NotValid", errors.KindNotValid, http.StatusBadRequest},
+		{"BadRequest", errors.KindBadRequest, http.StatusBadRequest},
+		{"ServiceUnavailable", errors.KindServiceUnavailable, http.StatusServiceUnavailable},
+		{"Conflict", errors.KindConflict, http.StatusConflict},
+		{"AlreadyExists", errors.KindAlreadyExists, http.StatusConflict},
+		{"NotImplemented", errors.KindNotImplemented, http.StatusNotImplemented},
+		{"NotProvisioned", errors.KindNotProvisioned, http.StatusNotImplemented},
+		{"Unauthorized", errors.KindUnauthorized, http.StatusUnauthorized},
+		{"Forbidden", errors.KindForbidden, http.StatusForbidden},
+		{"NotSupported", errors.KindNotSupported, http.StatusUnprocessableEntity},
+		{"NotAssigned", errors.KindNotAssigned, http.StatusUnprocessableEntity},
+		{"TooManyRequests", errors.KindTooManyRequests, http.StatusTooManyRequests},
+		{"Timeout", errors.KindTimeout, http.StatusRequestTimeout},
+		{"Internal", errors.KindInternal, http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HTTPStatusFor(tt.kind); got != tt.want {
+				t.Errorf("HTTPStatusFor(%v) = %d, want %d", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/skills/boost-factory-echo/SKILL.md
+++ b/skills/boost-factory-echo/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or reviewing Go HTTP API services that import git
 license: MIT
 metadata:
   author: jpfaria
-  version: "0.1.0"
+  version: "0.2.0"
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 
@@ -72,7 +72,7 @@ func main() {
 | `native/requestid` | X-Request-ID | Never |
 | `local/wrapper/log` | Access log via boost logger | Never |
 | `local/model/restresponse` | Sets `Type=REST` for `error_handler` JSON mode | Never (REST APIs) |
-| `extra/error_handler` | Maps `model/errors.*` to HTTP status + JSON envelope | Never |
+| `extra/error_handler` | Maps errors to HTTP status + JSON envelope via `model/errors.Classify` | Never |
 | `native/cors` | Browser clients | Internal-only services |
 | `native/gzip` | Response compression | gRPC / streaming |
 
@@ -94,6 +94,13 @@ srv.Shutdown(shutdownCtx) // bounded drain with FRESH ctx
 ```
 
 Use a fresh context for `Shutdown` — passing the cancelled parent makes it return immediately.
+
+## Custom error → status, or ignore
+
+The handler resolves status via `model/errors.Classify`. To make a non-boost
+error return a specific status (or be ignored / treated as 200), register it at
+boot — it works for HTTP and gRPC at once. See `boost-model-errors`
+(`Register`/`RegisterMatch`/`Ignore`); don't add cases to the handler by hand.
 
 ## Red flags
 

--- a/skills/boost-factory-grpc/SKILL.md
+++ b/skills/boost-factory-grpc/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when constructing a gRPC client or server in a Go service via 
 license: MIT
 metadata:
   author: jpfaria
-  version: "0.1.0"
+  version: "0.2.0"
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 
@@ -30,6 +30,18 @@ Configure under `boost.factory.grpc.client.*` and `boost.factory.grpc.server.*` 
 ## GCP-tuned variant
 
 For talking to GCP gRPC APIs (Pub/Sub, BigQuery, Firestore), the cloud-google factories compose `factory/contrib/cloud.google.com/grpc/v1` internally. You normally don't import it directly — you configure its keys at the per-service factory's `apiOptions` / `grpcOptions` namespace.
+
+## Error → gRPC code (and custom errors)
+
+The server converts errors to gRPC status via `server.Error(err)`, which resolves
+the code through `model/errors.Classify` (`NotFound`→`codes.NotFound`,
+`NotValid`/`BadRequest`→`InvalidArgument`, `Conflict`/`AlreadyExists`→
+`AlreadyExists`, `Unauthorized`→`Unauthenticated`, `Forbidden`→`PermissionDenied`,
+`ServiceUnavailable`→`Unavailable`, `NotImplemented`→`Unimplemented`,
+`TooManyRequests`→`ResourceExhausted`, `Timeout`→`DeadlineExceeded`, else
+`Internal`). To map an app-specific error to a code (or ignore it → returns
+`nil`/OK), register it at boot — see `boost-model-errors`
+(`Register`/`RegisterMatch`/`Ignore`). Don't edit `server.Error` by hand.
 
 ## Red flags
 

--- a/skills/boost-model-errors/SKILL.md
+++ b/skills/boost-model-errors/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boost-model-errors
-description: "Use when creating, wrapping, or matching errors in a Go service that imports github.com/xgodev/boost/model/errors. Covers the typed error catalog (BadRequest, NotFound, Conflict, Forbidden, Internal, NotValid, etc.), how Echo's error_handler plugin and the function publisher deadletter middleware match on these types, and why fmt.Errorf(%w) defeats both. Triggers on imports of github.com/xgodev/boost/model/errors, on questions about error wrapping in boost, on echo.NewHTTPError uses in a boost handler, or on Wrap / NotValidf / Internalf / NewBadRequest naming."
+description: "Use when creating, wrapping, or matching errors in a Go service that imports github.com/xgodev/boost/model/errors. Covers the typed error catalog (BadRequest, NotFound, Conflict, Forbidden, Internal, NotValid, etc.), how Echo's error_handler plugin and the function publisher deadletter middleware match on these types, why fmt.Errorf(%w) defeats both, and how to register custom (non-boost) errors so they map to HTTP/gRPC codes or get ignored. Triggers on imports of github.com/xgodev/boost/model/errors, on questions about error wrapping in boost, on echo.NewHTTPError uses in a boost handler, on Wrap / NotValidf / Internalf / NewBadRequest naming, or on errors.Register / RegisterMatch / Classify / Ignore / Kind, mapping a custom error to a status code, or ignoring an error."
 license: MIT
 metadata:
   author: jpfaria
-  version: "0.1.0"
+  version: "0.2.0"
 allowed-tools: Read Edit Write Glob Grep Bash(go:*) Bash(golangci-lint:*) Bash(git:*) Agent
 ---
 
@@ -34,6 +34,50 @@ Two boost subsystems pattern-match on the unwrapped error type name:
 
 `fmt.Errorf("%w", err)` defeats both because `errors.As(target *NotFound)` can't unwrap an opaque wrapped error of unknown concrete type. Always use `bootsterrors.Wrap`.
 
+The HTTP (Echo + function/CloudEvents) and gRPC error handlers resolve the status
+via `bootsterrors.Classify(err) Kind` — registered custom errors first, then the
+built-in `Is*` catalog. The `Kind → HTTP status` table lives in
+`model/restresponse` (`HTTPStatusFor`) and is shared by Echo and the function
+adapter; the `Kind → gRPC code` table lives in the gRPC `server` package.
+
+## Registering custom errors (map your own error → code, or ignore)
+
+For an application error that is **not** a boost type, register it once at boot
+(before serving) against a semantic `Kind`. It then resolves to the right HTTP
+status and gRPC code across all three transports — no per-transport wiring.
+
+```go
+import bootsterrors "github.com/xgodev/boost/model/errors"
+
+// "XptoError behaves like NotFound" → HTTP 404 / gRPC NotFound, everywhere.
+bootsterrors.Register(ErrXpto, bootsterrors.KindNotFound)         // matches via errors.Is
+
+bootsterrors.RegisterMatch(func(err error) bool {                // matches by type
+    _, ok := bootsterrors.Cause(err).(*MyTypedErr)               // Cause, like Is* does
+    return ok
+}, bootsterrors.KindConflict)
+
+// Ignore: no opts == treat as success (HTTP 200 / gRPC OK) AND silence the log.
+bootsterrors.Ignore(ErrNoise)
+bootsterrors.Ignore(ErrAudit, bootsterrors.IgnoreSilenceLog)     // status normal, just no log
+bootsterrors.Ignore(ErrExpected, bootsterrors.IgnoreAsSuccess)   // 200/OK, still logged
+bootsterrors.Ignore(ErrBoth, bootsterrors.IgnoreAsSuccess, bootsterrors.IgnoreSilenceLog) // explicit both
+```
+
+Opts are OR-combined; passing none is equivalent to passing both. `Ignore` matches
+via `errors.Is`; `IgnoreMatch(func(error) bool, ...IgnoreOption)` matches by predicate.
+
+`Kind` values mirror the catalog: `KindNotFound`, `KindBadRequest`, `KindNotValid`,
+`KindConflict`, `KindAlreadyExists`, `KindForbidden`, `KindUnauthorized`,
+`KindServiceUnavailable`, `KindNotImplemented`, `KindNotProvisioned`,
+`KindNotSupported`, `KindNotAssigned`, `KindMethodNotAllowed`,
+`KindTooManyRequests`, `KindTimeout`, `KindInternal` (default).
+
+Precedence in `Classify`: registered matchers (registration order, first wins) →
+built-in `Is*` → `KindInternal`. The `match` predicate runs while the registry
+lock is held — it must not call back into the registry (`Register`/`Classify`/
+`Ignore`/…) or it self-deadlocks.
+
 ## Red flags
 
 | Red flag | Fix |
@@ -42,3 +86,5 @@ Two boost subsystems pattern-match on the unwrapped error type name:
 | `echo.NewHTTPError(404, "...")` in a handler | `bootsterrors.NewNotFound(err, "...")` |
 | Returning a raw upstream error to a handler caller | Wrap with the right `bootsterrors.New<Type>` so the matcher can route it |
 | Inventing a custom error struct for things `model/errors` already covers | Use the existing type — extending the catalog needs an upstream PR, not a local workaround |
+| A genuinely app-specific error returning 500 because the handler doesn't know it | `bootsterrors.Register(err, Kind…)` / `RegisterMatch(...)` at boot so it maps to the right code in HTTP and gRPC |
+| Editing the Echo/gRPC switch by hand to add a case for your error | Register it instead — the switch is now a shared `Classify` + `Kind` table |


### PR DESCRIPTION
## Contexto

Os error handlers de HTTP (Echo), gRPC e function/CloudEvents só entendiam os
tipos de erro do próprio boost, e o mapeamento erro→código estava **triplicado**
(o mesmo `switch errors.Is*` em 3 arquivos). Não havia como registrar um erro da
aplicação e dizer o código que ele retorna, nem ignorar erros.

## O que muda

Um **registry único** em `model/errors` que os 3 transportes consomem:

```go
// no boot, antes de servir:
errors.Register(ErrXpto, errors.KindNotFound)        // → 404 HTTP / NotFound gRPC
errors.RegisterMatch(func(e error) bool {            // match por tipo
    _, ok := errors.Cause(e).(*MyErr); return ok
}, errors.KindConflict)
errors.Ignore(ErrNoise)                              // 200/OK + sem log
errors.Ignore(ErrAudit, errors.IgnoreSilenceLog)     // status normal, sem log
```

Registra uma vez, vale em **HTTP (Echo), gRPC e function/CloudEvents**.

## Detalhes

- `model/errors`: enum `Kind` (espelha o catálogo) + registry thread-safe
  (`Register`/`RegisterMatch`/`Classify`, `Ignore`/`IgnoreMatch`/`IgnoreOf`,
  `ResetRegistry`). Precedência: registrados → `Is*` embutido → `KindInternal`.
  Sem dependência de transporte (não importa `net/http` nem `grpc/codes`).
- `model/restresponse.HTTPStatusFor(Kind)`: tabela HTTP compartilhada por Echo e
  function/CE (mata a duplicação).
- Tabela `Kind → gRPC code` no pacote `grpc/v1/server`.
- 3 handlers refatorados para classificar via `Classify` + honrar
  ignore-as-success (HTTP 200 / gRPC OK).
- Middlewares de log (Echo + gRPC) honram `IgnoreSilenceLog`.
- **Comportamento preservado**: todo tipo de erro boost mapeia para o mesmo
  status/code de antes (verificado caso a caso na revisão final). `validator`
  segue tratado em cada transporte.
- **Gap fechado de brinde**: `Timeout` (408 / DeadlineExceeded) e
  `TooManyRequests` (429 / ResourceExhausted), que antes caíam em 500/Internal.
- Skills `boost-model-errors`/`boost-factory-echo`/`boost-factory-grpc`
  atualizadas + plugin `golang-boost` 0.8.0 → 0.9.0 (Iron Law #6).

## Como foi feito

TDD task a task (spec → plano → subagentes implementador + revisão de spec +
revisão de qualidade). Spec e plano em `docs/superpowers/`.

## Test Plan

- [x] `go test ./model/errors/... ./model/restresponse/...` verde
- [x] `go test` dos 3 transportes (echo, grpc/server, cloudevents http) verde
- [x] `gofmt`/`go vet` limpos nos pacotes tocados
- [ ] quality-gate comparativo (rodar antes do merge)

> Nota: `go test ./...` global falha em `factory/core/database/sql/.../otelsql`
> por mismatch de versão de dependência **pré-existente na `main`** (não tocado
> por este PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)