### PR TITLE
fix(kafka-adapter): make config namespace env-reachable (#48)

### DIFF
--- a/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/config.go
+++ b/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/config.go
@@ -7,7 +7,13 @@ import (
 )
 
 const (
-	root         = adapter.Root + ".kafka_confluent"
+	root = adapter.Root + ".confluent"
+	// legacyRoot is the pre-#48 namespace. Its literal underscore makes every
+	// key unreachable from env vars (the loader can never emit a segment with
+	// an underscore), so it was renamed to ".confluent". Kept only so values
+	// still set under it via a config file keep working. Deprecated.
+	legacyRoot = adapter.Root + ".kafka_confluent"
+
 	topics       = root + ".topics"
 	timeOut      = root + ".timeOut"
 	manualCommit = root + ".manualCommit"

--- a/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/config_test.go
+++ b/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/config_test.go
@@ -1,0 +1,45 @@
+package confluent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xgodev/boost/wrapper/config"
+	koanf "github.com/xgodev/boost/wrapper/config/contrib/knadh/koanf/v1"
+	"github.com/xgodev/boost/wrapper/config/model"
+)
+
+// Issue #48: every key under this adapter's root must be reachable from env
+// vars. The old root ".kafka_confluent" produced a segment with a literal
+// underscore, which the env loader can never emit, so BOOST_..._CONFLUENT_*
+// silently did nothing.
+func TestConfig_EnvVarReachesTopics(t *testing.T) {
+	t.Setenv("BOOST_BOOTSTRAP_FUNCTION_ADAPTER_CONFLUENT_TOPICS", "orders")
+
+	config.Set(koanf.New())
+	config.Load()
+
+	opts, err := DefaultOptions()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"orders"}, opts.Topics)
+}
+
+// Backward compat: values set under the legacy ".kafka_confluent" root via a
+// config file must keep working after the rename to ".confluent".
+func TestConfig_LegacyFileNamespaceStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "legacy.json")
+	err := os.WriteFile(f, []byte(
+		`{"boost":{"bootstrap":{"function":{"adapter":{"kafka_confluent":{"topics":["legacy"]}}}}}}`), 0o644)
+	assert.NoError(t, err)
+	t.Setenv(model.ConfEnvironment, f)
+
+	config.Set(koanf.New())
+	config.Load()
+
+	opts, err := DefaultOptions()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"legacy"}, opts.Topics)
+}

--- a/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/options.go
+++ b/bootstrap/function/adapter/contrib/confluentinc/confluent-kafka-go/v2/options.go
@@ -19,5 +19,11 @@ type Options struct {
 
 // DefaultOptions returns options based in config.
 func DefaultOptions() (*Options, error) {
-	return config.NewOptionsWithPath[Options](root)
+	opts, err := config.NewOptionsWithPath[Options](root)
+	if err != nil {
+		return nil, err
+	}
+	// Backward compat (issue #48): merge any values still set under the legacy
+	// ".kafka_confluent" root via a config file. Absent -> no-op. Deprecated.
+	return config.MergeOptionsWithPath[Options](opts, legacyRoot)
 }


### PR DESCRIPTION
Closes #48.

## Problem
The confluent kafka function adapter registered its config under `adapter.Root + ".kafka_confluent"`. The env loader uses `_` as the path separator and `__` as the camelCase marker, so **no env var can produce a segment with a literal underscore**. Every key under `boost.bootstrap.function.adapter.kafka_confluent.*` was unreachable from the environment — operators setting `BOOST_BOOTSTRAP_FUNCTION_ADAPTER_KAFKA_CONFLUENT_TOPICS` got no error and the adapter silently ran on defaults.

## Fix
Rename the root to `.confluent`:
- `BOOST_BOOTSTRAP_FUNCTION_ADAPTER_CONFLUENT_*` now works.
- Consistent with the sibling adapters (`.nats` / `.pubsub` / `.cloudevents`) and the factory namespace `boost.factory.confluent`.
- **Backward compat:** values still set under the legacy `.kafka_confluent` root via a config file are merged as a deprecated fallback in `DefaultOptions`, so existing file-based configs keep working (env-only rename would have broken them).

## Tests
`config_test.go` covers both:
- `TestConfig_EnvVarReachesTopics` — the env var now reaches `Options.Topics` (was red before the fix).
- `TestConfig_LegacyFileNamespaceStillWorks` — a config file under the old `kafka_confluent` root still applies.

## Docs
Plugin doc synced in `xgodev/boost-claude` (branch `fix/48-confluent-env-namespace`): corrected the adapter config namespace and split broker/group (factory) from adapter tuning. That PR is a follow-up in the other repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)